### PR TITLE
Add `toAssoc` and `mapToAssoc` macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,41 @@ collect(['sebastian@spatie.be', 'bla'])->validate('email'); // returns false
 collect(['sebastian@spatie.be', 'freek@spatie.be'])->validate('email'); // returns true
 ```
 
+### `toAssoc`
+
+Transform a collection into an associative array form collection item.
+
+```php
+$collection = collect(['a', 'b'], ['c', 'd'], ['e', 'f'])->toAssoc();
+
+$collection->toArray(); // returns ['a' => 'b', 'c' => 'd', 'e' => 'f']
+```
+
+### `mapToAssoc`
+
+Transform a collection into an associative array form collection item, allowing you to pass a callback to customize its key and value through a map operation.
+
+```php
+$employees = collect([
+    [
+        'name' => 'John',
+        'department' => 'Sales',
+        'email' => 'john@example.com',
+    ],
+    [
+        'name' => 'Jane',
+        'department' => 'Marketing',
+        'email' => 'jane@example.com',
+    ],
+]);
+
+$employees->mapToAssoc(function ($employee) {
+    return [$employee['email'], $employee['name']];
+});
+
+$employees->toArray(); // returns ['john@example.com' => 'John', 'jane@example.com' => 'Jane']
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/src/macros.php
+++ b/src/macros.php
@@ -175,3 +175,36 @@ if (!Collection::hasMacro('groupByModel')) {
         })->values();
     });
 }
+
+if (!Collection::hasMacro('toAssoc')) {
+    /*
+     * Transform a collection into an associative array form collection item.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    Collection::macro('toAssoc', function () {
+
+        return $this->reduce(function ($assoc, array $keyValuePair): Collection {
+            list($key, $value) = $keyValuePair;
+            $assoc[$key] = $value;
+
+            return $assoc;
+        }, new static );
+    });
+}
+
+if (!Collection::hasMacro('mapToAssoc')) {
+
+    /*
+     * Transform a collection into an associative array form collection item,
+     * allowing you to pass a callback to customize its key and value
+     * through a map operation.
+     *
+     * @param callable callback
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    Collection::macro('mapToAssoc', function (callable $callback): Collection {
+        return $this->map($callback)->toAssoc();
+    });
+}

--- a/tests/MapToAssocTest.php
+++ b/tests/MapToAssocTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test;
+
+use Illuminate\Support\Collection;
+
+class MapToAssocTest extends TestCase
+{
+    /** @test */
+    public function it_provides_a_mapToAssoc_macro()
+    {
+        $this->assertTrue(Collection::hasMacro('mapToAssoc'));
+    }
+
+    /** @test */
+    public function it_can_map_a_collection_and_transform_it_into_an_associative_array()
+    {
+        $employees = collect([
+            [
+                'name' => 'John',
+                'department' => 'Sales',
+                'email' => 'john@example.com',
+            ],
+            [
+                'name' => 'Jane',
+                'department' => 'Marketing',
+                'email' => 'jane@example.com',
+            ],
+            [
+                'name' => 'Dave',
+                'department' => 'Marketing',
+                'email' => 'dave@example.com',
+            ],
+        ]);
+
+        $this->assertEquals([
+            'john@example.com' => 'John',
+            'jane@example.com' => 'Jane',
+            'dave@example.com' => 'Dave',
+        ], $employees->mapToAssoc(function ($employee) {
+            return [$employee['email'], $employee['name']];
+        })->toArray());
+    }
+}

--- a/tests/ToAssocTest.php
+++ b/tests/ToAssocTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test;
+
+use Illuminate\Support\Collection;
+
+class ToAssocTest extends TestCase
+{
+    /** @test */
+    public function it_provides_a_toAssoc_macro()
+    {
+        $this->assertTrue(Collection::hasMacro('toAssoc'));
+    }
+
+    /** @test */
+    public function it_can_transform_a_collection_into_an_associative_array()
+    {
+        $this->assertEquals([
+            'john@example.com' => 'John',
+            'jane@example.com' => 'Jane',
+            'dave@example.com' => 'Dave',
+        ], Collection::make([
+            ['john@example.com', 'John'],
+            ['jane@example.com', 'Jane'],
+            ['dave@example.com', 'Dave'],
+        ])->toAssoc()->toArray());
+    }
+}


### PR DESCRIPTION
Hey @freekmurze,

Here's my shot at adding those 2 macros from Adam's [article] (https://adamwathan.me/2016/07/14/customizing-keys-when-mapping-collections/) like you requested in #2. It might deserve a bit more tests though.

Thanks a lot for all of Spatie's OSS packages. You guys are really delivering the most useful Laravel libraries these days. We are very grateful for it at AREA 17 and are planning to send a postcard your way asap :)