### PR TITLE
Improvements to transpose macro.

### DIFF
--- a/src/macros.php
+++ b/src/macros.php
@@ -205,11 +205,22 @@ if (! Collection::hasMacro('transpose')) {
      * Transpose an array.
      *
      * @return \Illuminate\Support\Collection
+     *
+     * @throws \LengthException
      */
     Collection::macro('transpose', function (): Collection {
+        $values = $this->values();
+
+        $expectedLength = count($this->first());
+        $diffLength = count(array_intersect_key(...$values));
+
+        if ($expectedLength !== $diffLength) {
+            throw new \LengthException("Element's length must be equal.");
+        }
+
         $items = array_map(function (...$items) {
-            return $items;
-        }, ...$this->values());
+            return new static($items);
+        }, ...$values);
 
         return new static($items);
     });

--- a/tests/TransposeTest.php
+++ b/tests/TransposeTest.php
@@ -9,13 +9,50 @@ class TransposeTest extends TestCase
     /** @test */
     public function it_can_transpose_an_array()
     {
-        $collection = Collection::make(
-            [['foo', 'foo1'], ['bar', 'bar1'], ['baz', 'baz1']]
-        );
+        $collection = new Collection([
+            ['11', '12', '13'],
+            ['21', '22', '23'],
+            ['31', '32', '33'],
+        ]);
+        $expected = new Collection([
+            new Collection(['11', '21', '31']),
+            new Collection(['12', '22', '32']),
+            new Collection(['13', '23', '33']),
+        ]);
 
-        $this->assertEquals(
-            [['foo', 'bar', 'baz'], ['foo1', 'bar1', 'baz1']],
-            $collection->transpose()->toArray()
-        );
+        $this->assertEquals($expected, $collection->transpose());
+    }
+
+    /** @test */
+    public function it_will_enforce_length_equality()
+    {
+        $this->expectException(\LengthException::class);
+        $this->expectExceptionMessage("Element's length must be equal.");
+
+        $collection = new Collection([
+            ['11', '12', '13'],
+            ['21', '22'],
+            ['31', '32', '33'],
+        ]);
+
+        $collection->transpose();
+    }
+
+    /** @test */
+    public function it_will_remove_existing_keys()
+    {
+        $collection = new Collection([
+            'one' => ['11', '12', '13'],
+            'two' => ['21', '22', '23'],
+            'three' => ['31', '32', '33'],
+        ]);
+
+        $expected = new Collection([
+            new Collection(['11', '21', '31']),
+            new Collection(['12', '22', '32']),
+            new Collection(['13', '23', '33']),
+        ]);
+
+        $this->assertEquals($expected, $collection->transpose());
     }
 }


### PR DESCRIPTION
Proposal:

1. it should blow if the elements are not equal in length, compatible with rails implementation;
2. it should return a collection of collections;
3. should test keys removal for documentation purposes.

Thank you.