### PR TITLE
Fix flipped arguments passed to version_compare.

### DIFF
--- a/tests/NoneTest.php
+++ b/tests/NoneTest.php
@@ -26,7 +26,7 @@ class NoneTest extends TestCase
     {
         // Below Laravel 5.3, the callable's parameter order is `$key, $value`.
 
-        if (version_compare('5.3.0', Application::VERSION, 'lt')) {
+        if (version_compare(Application::VERSION, '5.3.0', 'lt')) {
             $this->assertTrue(Collection::make(['name' => 'foo'])->none(function ($key, $value) {
                 return $key === 'name' && $value === 'bar';
             }));


### PR DESCRIPTION
The tests were failing, because the first two arguments supplied to [version_compare](http://php.net/manual/en/function.version-compare.php), were flipped.

If we say `$version1 = '5.3.4'`, `$version2 = '5.3.0'`, and the `$operator = 'lt'`, then it makes sense through this sentence:
> if `$version1` is `$operator` than `$arg2`

The failing test really got my head spinning, but since PHP is not very consistent, when it comes to `($haystack, $needle)` or `($needle, $haystack)`, I figured the error might lie in the order of the parameters.