### PR TITLE
Fix error when splitting an empty collection. (closes #13)

### DIFF
--- a/src/macros.php
+++ b/src/macros.php
@@ -110,6 +110,9 @@ if (! Collection::hasMacro('split')) {
      * @return \Illuminate\Support\Collection
      */
     Collection::macro('split', function (int $numberOfGroups): Collection {
+        if($this->isEmpty()) {
+            return $this;
+        }
         $groupSize = ceil($this->count() / $numberOfGroups);
 
         return $this->chunk($groupSize);

--- a/tests/SplitTest.php
+++ b/tests/SplitTest.php
@@ -38,4 +38,15 @@ class SplitTest extends TestCase
             })->toArray()
         );
     }
+
+    /** @test */
+    public function it_can_split_an_empty_collection_without_getting_an_error()
+    {
+        $this->assertEquals(
+            [],
+            Collection::make([])->split(2)->map(function (Collection $chunk) {
+                return $chunk->values()->toArray();
+            })->toArray()
+        );
+    }
 }


### PR DESCRIPTION
Here is the accompanying code to fix the bug mentioned in #13.

I've added an additional test for making sure splitting an empty collection returns an empty collection. 

I hope this suits your code-style. :)