### PR TITLE
toAssoc() should accept an associative array and return an array

### DIFF
--- a/src/macros.php
+++ b/src/macros.php
@@ -191,17 +191,12 @@ if (! Collection::hasMacro('groupByModel')) {
 
 if (! Collection::hasMacro('toAssoc')) {
     /*
-     * Transform a collection into an associative array form collection item.
+     * Transform a collection into an associative array
      *
      * @return \Illuminate\Support\Collection
      */
     Collection::macro('toAssoc', function () {
-        return $this->reduce(function ($assoc, array $keyValuePair): Collection {
-            list($key, $value) = $keyValuePair;
-            $assoc[$key] = $value;
-
-            return $assoc;
-        }, new static);
+        return $this->collapse()->toArray();
     });
 }
 
@@ -213,9 +208,9 @@ if (! Collection::hasMacro('mapToAssoc')) {
      *
      * @param callable callback
      *
-     * @return \Illuminate\Support\Collection
+     * @return array
      */
-    Collection::macro('mapToAssoc', function (callable $callback): Collection {
+    Collection::macro('mapToAssoc', function (callable $callback) {
         return $this->map($callback)->toAssoc();
     });
 }

--- a/tests/MapToAssocTest.php
+++ b/tests/MapToAssocTest.php
@@ -15,6 +15,12 @@ class MapToAssocTest extends TestCase
     /** @test */
     public function it_can_map_a_collection_and_transform_it_into_an_associative_array()
     {
+        $expected = [
+            'john@example.com' => 'John',
+            'jane@example.com' => 'Jane',
+            'dave@example.com' => 'Dave',
+        ];
+
         $employees = collect([
             [
                 'name' => 'John',
@@ -33,12 +39,11 @@ class MapToAssocTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals([
-            'john@example.com' => 'John',
-            'jane@example.com' => 'Jane',
-            'dave@example.com' => 'Dave',
-        ], $employees->mapToAssoc(function ($employee) {
-            return [$employee['email'], $employee['name']];
-        })->toArray());
+        $this->assertEquals(
+            $expected,
+            $employees->mapToAssoc(function ($employee) {
+                return [$employee['email'] => $employee['name']];
+            })
+        );
     }
 }

--- a/tests/ToAssocTest.php
+++ b/tests/ToAssocTest.php
@@ -15,14 +15,19 @@ class ToAssocTest extends TestCase
     /** @test */
     public function it_can_transform_a_collection_into_an_associative_array()
     {
-        $this->assertEquals([
+        $expected = [
             'john@example.com' => 'John',
             'jane@example.com' => 'Jane',
             'dave@example.com' => 'Dave',
-        ], Collection::make([
-            ['john@example.com', 'John'],
-            ['jane@example.com', 'Jane'],
-            ['dave@example.com', 'Dave'],
-        ])->toAssoc()->toArray());
+        ];
+
+        $this->assertEquals(
+            $expected,
+            collect([
+                ['john@example.com' => 'John'],
+                ['jane@example.com' => 'Jane'],
+                ['dave@example.com' => 'Dave'],
+            ])->toAssoc()
+        );
     }
 }


### PR DESCRIPTION
Hello Freek.

I'm aware that this is a breaking change, sorry.

In my opinion, `toAssoc` was not implemented in the best way possible.

I find it very unpleasant and *not normal* to work with pairs, like this:

```php
$employees->mapToAssoc(function ($employee) {
    return [$employee['email'], $employee['name']];
})
```

 I think it would be better if `maptoAssoc` expected associative arrays, like this:

```php
$employees->mapToAssoc(function ($employee) {
    return [$employee['email'] => $employee['name']];
})
```

Also, I don't think it makes sense for `toAssoc` to return a `Collection`. 
Returning a `Collection` means `toAssoc` will do the same that `collapse` does. 
Also, if the name of the function is `toAssoc` I would expect an associative array in return.

That's just an opinion, feel free to ditch it, please.

Thank you for your attention,

Alvaro Guimaraes.