### PR TITLE
Add pad macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All Notable changes to `laravel-collection-macros` will be documented in this file
 
+## Unreleased
+- add `pad` macro
+
 ## 1.4.4 - 2016-09-01
 - `split` doesn't throw an error anymore when trying to split an empty collection
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,28 @@ $collection->first(); // returns a collection with 'a' and 'b';
 $collection->last(); // returns a collection with 'e' and 'f';
 ```
 
+### `pad`
+
+Pads a collection with the given minimum number of items with the specified value.
+
+```php
+$collection = collect(['a', 'b', 'c', 'd', 'e', 'f'])->pad(7, 'g');
+
+$collection->count(); // returns 7
+
+$collection->dump(); // dumps ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+```
+
+If the collection has more values than the minimum number to pad, then it will not add extra values.
+
+```php
+$collection = collect(['a', 'b', 'c', 'd', 'e', 'f'])->pad(3, 'x');
+
+$collection->count(); // returns 6
+
+$collection->dump(); // dumps ['a', 'b', 'c', 'd', 'e', 'f']
+```
+
 ### `validate`
 
 Returns `true` if the given `$callback` returns true for every item. If `$callback` is a string or an array, regard it as a validation rule.

--- a/src/macros.php
+++ b/src/macros.php
@@ -120,6 +120,24 @@ if (! Collection::hasMacro('split')) {
     });
 }
 
+if (! Collection::hasMacro('pad')) {
+    /*
+     * Pad a collection to a specific minimum length with a value
+     *
+     * @param int $minimumLength
+     * @param mixed $padWithValue
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    Collection::macro('pad', function (int $minimumLength, $padWithValue): Collection {
+        if ($this->isEmpty() || $this->count() < $minimumLength) {
+            return new static(array_pad($this->toArray(), $minimumLength, $padWithValue));
+        }
+
+        return $this;
+    });
+}
+
 if (! Collection::hasMacro('validate')) {
     /*
      * Returns true if $callback returns true for every item. If $callback

--- a/tests/PadTest.php
+++ b/tests/PadTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test;
+
+use Illuminate\Support\Collection;
+
+class PadTest extends TestCase
+{
+    /** @test */
+    public function it_can_pad_a_collection_if_the_count_is_less()
+    {
+        $this->assertCount(5, Collection::make(['a', 'b', 'c', 'd'])->pad(5, '')->toArray());
+    }
+
+    /** @test */
+    public function it_can_pad_a_collection_if_the_count_is_more()
+    {
+        $this->assertCount(4, Collection::make(['a', 'b', 'c', 'd'])->pad(2, '')->toArray());
+    }
+
+    /** @test */
+    public function it_can_pad_an_empty_collection_without_getting_an_error()
+    {
+        $this->assertCount(2, Collection::make([])->pad(2, '')->toArray());
+    }
+}


### PR DESCRIPTION
Uses `array_pad` while still utilizing the power of Collections.