### PR TITLE
Add `collect` Macro

### DIFF
--- a/src/macros.php
+++ b/src/macros.php
@@ -241,3 +241,17 @@ if (! Collection::hasMacro('transpose')) {
         return new static($items);
     });
 }
+
+if (! Collection::hasMacro('collect')) {
+    /**
+     * Get a new collection from the collection by key.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $default
+     *
+     * @return static
+     */
+    Collection::macro('collect', function ($key, $default = null) {
+        return new Collection($this->get($key, $default));
+    });
+}

--- a/src/macros.php
+++ b/src/macros.php
@@ -243,7 +243,7 @@ if (! Collection::hasMacro('transpose')) {
 }
 
 if (! Collection::hasMacro('collect')) {
-    /**
+    /*
      * Get a new collection from the collection by key.
      *
      * @param  mixed  $key

--- a/tests/CollectTest.php
+++ b/tests/CollectTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test;
+
+use Illuminate\Support\Collection;
+
+class CollectTest extends TestCase
+{
+    /** @test */
+    public function it_provides_a_collect_macro()
+    {
+        $this->assertTrue(Collection::hasMacro('collect'));
+    }
+
+    /** @test */
+    public function it_returns_a_collection()
+    {
+        $collection = new Collection([
+            'name' => 'taco',
+            'ingredients' => [
+                'cheese',
+                'lettuce',
+                'beef',
+                'tortilla',
+            ],
+            'should_eat' => true,
+        ]);
+
+        $ingredients = $collection->collect('ingredients');
+
+        $this->assertTrue(is_a($ingredients, Collection::class));
+    }
+
+    /** @test */
+    public function it_returns_default_when_key_is_missing()
+    {
+        $collection = new Collection([
+            'name' => 'taco',
+            'ingredients' => [
+                'cheese',
+                'lettuce',
+                'beef',
+                'tortilla',
+            ],
+            'should_eat' => true,
+        ]);
+
+        $ingredients = $collection->collect('build_it', $collection->get('ingredients'));
+
+        $this->assertEquals($collection->collect('ingredients'), $ingredients);
+    }
+
+    /** @test */
+    public function it_returns_empty_collection_when_missing_key_without_default()
+    {
+        $collection = new Collection([
+            'name' => 'taco',
+            'ingredients' => [
+                'cheese',
+                'lettuce',
+                'beef',
+                'tortilla',
+            ],
+            'should_eat' => true,
+        ]);
+
+        $ingredients = $collection->collect('build_it');
+
+        $this->assertEquals(new Collection, $ingredients);
+    }
+}

--- a/tests/ValidateTest.php
+++ b/tests/ValidateTest.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\CollectionMacros\Test;
 
-use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use Illuminate\Support\Collection;
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 class ValidateTest extends OrchestraTestCase
 {

--- a/tests/ValidateTest.php
+++ b/tests/ValidateTest.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\CollectionMacros\Test;
 
-use Orchestra\Testbench\TestCase;
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use Illuminate\Support\Collection;
 
-class ValidateTest extends TestCase
+class ValidateTest extends OrchestraTestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
I constantly find myself needing to “re-collect” nested arrays after getting them. I propose adding a `collect` macro to the Collection class.