### PR TITLE
Group collections on multiple fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,68 @@ $collection = collect([
 $collection->collect('baz', ['Nope']); // Collection(['Nope'])
 ```
 
+### `groupByMultiple`
+
+Similar call signature and functionality to groupBy(), but allows grouping on multiple fields.
+Compared to groupBy(), this variant does not support passing a callable as an array for obvious reasons.
+Passing an array of array-callables works just fine.
+
+```php
+$collection = collect([
+          ['A' => 'foo', 'B' => 'bar',    'C' => 'baz',    'D' => 'thud'],
+          ['A' => 'foo', 'B' => 'garply', 'C' => 'corge',  'D' => 'plugh'],
+          ['A' => 'foo', 'B' => 'bar',    'C' => 'corge',  'D' => 'thud'],
+          ['A' => 'foo', 'B' => 'bar',    'C' => 'corge',  'D' => 'waldo'],
+          ['A' => 'qux', 'B' => 'garply', 'C' => 'xyzzy',  'D' => 'fred'],
+          ['A' => 'qux', 'B' => 'grault', 'C' => 'garply', 'D' => 'quuz'],
+        ]);
+$collection->groupByMultiple(['A', 'B', 'C', 'D']);
+/*
+Collection([
+  'foo' => [
+    'bar' => [
+      'baz' => [
+        'thud' => [
+          ['A' => 'foo', 'B' => 'bar',    'C' => 'baz',    'D' => 'thud'],
+        ],
+      ],
+      'corge' => [
+        'thud' => [
+          ['A' => 'foo', 'B' => 'bar',    'C' => 'corge',  'D' => 'thud'],
+        ],
+        'waldo' => [
+          ['A' => 'foo', 'B' => 'bar',    'C' => 'corge',  'D' => 'waldo'],
+        ],
+      ],
+    ],
+    'garply' => [
+      'corge' => [
+        'plugh' => [
+          ['A' => 'foo', 'B' => 'garply', 'C' => 'corge',  'D' => 'plugh'],
+        ],
+      ],
+    ],
+  ],
+  'qux' => [
+    'garply' => [
+      'xyzzy' => [
+        'fred' => [
+          ['A' => 'qux', 'B' => 'garply', 'C' => 'xyzzy',  'D' => 'fred'],
+        ],
+      ],
+    ],
+    'grault' => [
+      'garply' => [
+        'quuz' => [
+          ['A' => 'qux', 'B' => 'grault', 'C' => 'garply', 'D' => 'quuz'],
+        ],
+      ],
+    ],
+  ],
+]);
+*/
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/src/macros.php
+++ b/src/macros.php
@@ -297,3 +297,69 @@ if (! Collection::hasMacro('before')) {
         return $this->reverse()->after($currentItem, $fallback);
     });
 }
+
+if (! Collection::hasMacro('groupByMultiple')) {
+    /**
+     * Group an associative array by multiple fields or callbacks.
+     *
+     * @param  string|array  $groupBy
+     * @param  bool  $preserveKeys
+     * @return Collection
+     */
+    Collection::macro('groupByMultiple', function ($groupBy, $preserveKeys = false): Collection {
+        if (! is_array($groupBy)) {
+            $groupBy = [$groupBy];
+        }
+
+        $groupKeyRetrievers = [];
+        foreach ($groupBy as $currentGroupBy) {
+            $groupKeyRetrievers[] = $this->valueRetriever($currentGroupBy);
+        }
+
+        $results = [];
+
+        foreach ($this->items as $key => $value) {
+            $currentLevel = [&$results];
+            $nextLevel = [];
+            foreach ($groupKeyRetrievers as $currentGroupBy) {
+                $groupKeys = $currentGroupBy($value);
+                if (! is_array($groupKeys)) {
+                    $groupKeys = [$groupKeys];
+                }
+                foreach ($groupKeys as $groupKey) {
+                    foreach ($currentLevel as &$subGroup) {
+                        if (! array_key_exists($groupKey, $subGroup)) {
+                            $subGroup[$groupKey] = [];
+                        }
+                        $nextLevel[] = &$subGroup[$groupKey];
+                    }
+                }
+                $currentLevel = $nextLevel;
+                $nextLevel = [];
+            }
+            if ($preserveKeys && ! is_null($key)) {
+                foreach ($currentLevel as &$lastLevel) {
+                    $lastLevel[$key] = $value;
+                }
+            } else {
+                foreach ($currentLevel as &$lastLevel) {
+                    $lastLevel[] = $value;
+                }
+            }
+        }
+
+        $toNestedCollection = function(&$array) use (&$toNestedCollection) {
+            if (is_array($array)) {
+                foreach ($array as &$subArray) {
+                    $subArray = $toNestedCollection($subArray);
+                }
+
+                return new Collection($array);
+            } else {
+                return $array;
+            }
+        };
+
+        return $toNestedCollection($results);
+    });
+}

--- a/src/macros.php
+++ b/src/macros.php
@@ -354,7 +354,7 @@ if (! Collection::hasMacro('groupByMultiple')) {
                     $subArray = $toNestedCollection($subArray);
                 }
 
-                return new Collection($array);
+                return new static($array);
             } else {
                 return $array;
             }

--- a/src/macros.php
+++ b/src/macros.php
@@ -299,7 +299,7 @@ if (! Collection::hasMacro('before')) {
 }
 
 if (! Collection::hasMacro('groupByMultiple')) {
-    /**
+    /*
      * Group an associative array by multiple fields or callbacks.
      *
      * @param  string|array  $groupBy
@@ -348,7 +348,7 @@ if (! Collection::hasMacro('groupByMultiple')) {
             }
         }
 
-        $toNestedCollection = function(&$array) use (&$toNestedCollection) {
+        $toNestedCollection = function (&$array) use (&$toNestedCollection) {
             if (is_array($array)) {
                 foreach ($array as &$subArray) {
                     $subArray = $toNestedCollection($subArray);

--- a/tests/GroupByMultipleTest.php
+++ b/tests/GroupByMultipleTest.php
@@ -106,7 +106,6 @@ class GroupByMultipleTest extends TestCase
           20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
           30 => ['user' => 3, 'roles' => ['Role_1']],
         ]);
-        $dataM = clone $data;
 
         $callback = function ($item) {
             return $item['roles'];

--- a/tests/GroupByMultipleTest.php
+++ b/tests/GroupByMultipleTest.php
@@ -1,0 +1,404 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test;
+
+use Illuminate\Support\Collection;
+
+class GroupByMultipleTest extends TestCase
+{
+    /** @test */
+    public function testGroupByAttribute()
+    {
+        $data = new Collection([['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1'], ['rating' => 2, 'url' => '2']]);
+
+        $expected = [1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]];
+        $result = $data->groupByMultiple('rating');
+        $this->assertEquals($expected, $result->toArray());
+
+        $expected = [1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]];
+        $result = $data->groupByMultiple('url');
+        $this->assertEquals($expected, $result->toArray());
+    }
+
+    /** @test */
+    public function testGroupByAttributePreservingKeys()
+    {
+        $data = new Collection([10 => ['rating' => 1, 'url' => '1'],  20 => ['rating' => 1, 'url' => '1'],  30 => ['rating' => 2, 'url' => '2']]);
+
+        $result = $data->groupByMultiple('rating', true);
+
+        $expected_result = [
+          1 => [10 => ['rating' => 1, 'url' => '1'], 20 => ['rating' => 1, 'url' => '1']],
+          2 => [30 => ['rating' => 2, 'url' => '2']],
+        ];
+
+        $this->assertEquals($expected_result, $result->toArray());
+    }
+
+    /** @test */
+    public function testGroupByClosureWhereItemsHaveSingleGroup()
+    {
+        $data = new Collection([['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1'], ['rating' => 2, 'url' => '2']]);
+
+        $callback = function ($item) {
+            return $item['rating'];
+        };
+        $result = $data->groupByMultiple($callback);
+
+        $expected = [1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]];
+        $this->assertEquals($expected, $result->toArray());
+    }
+
+    /** @test */
+    public function testGroupByClosureWhereItemsHaveSingleGroupPreservingKeys()
+    {
+        $data = new Collection([10 => ['rating' => 1, 'url' => '1'], 20 => ['rating' => 1, 'url' => '1'], 30 => ['rating' => 2, 'url' => '2']]);
+
+        $callback = function ($item) {
+            return $item['rating'];
+        };
+        $result = $data->groupByMultiple($callback, true);
+
+        $expected_result = [
+          1 => [10 => ['rating' => 1, 'url' => '1'], 20 => ['rating' => 1, 'url' => '1']],
+          2 => [30 => ['rating' => 2, 'url' => '2']],
+        ];
+
+        $this->assertEquals($expected_result, $result->toArray());
+    }
+
+    /** @test */
+    public function testGroupByClosureWhereItemsHaveMultipleGroups()
+    {
+        $data = new Collection([
+          ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
+          ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
+          ['user' => 3, 'roles' => ['Role_1']],
+        ]);
+
+        $callback = function ($item) {
+            return $item['roles'];
+        };
+        $result = $data->groupByMultiple($callback);
+
+        $expected_result = [
+          'Role_1' => [
+            ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
+            ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
+            ['user' => 3, 'roles' => ['Role_1']],
+          ],
+          'Role_2' => [
+            ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
+          ],
+          'Role_3' => [
+            ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
+          ],
+        ];
+
+        $this->assertEquals($expected_result, $result->toArray());
+    }
+
+    /** @test */
+    public function testGroupByClosureWhereItemsHaveMultipleGroupsPreservingKeys()
+    {
+        $data = new Collection([
+          10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
+          20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
+          30 => ['user' => 3, 'roles' => ['Role_1']],
+        ]);
+        $dataM = clone $data;
+
+        $callback = function ($item) {
+            return $item['roles'];
+        };
+        $result = $data->groupByMultiple($callback, true);
+
+        $expected_result = [
+          'Role_1' => [
+            10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
+            20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
+            30 => ['user' => 3, 'roles' => ['Role_1']],
+          ],
+          'Role_2' => [
+            20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
+          ],
+          'Role_3' => [
+            10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
+          ],
+        ];
+
+        $this->assertEquals($expected_result, $result->toArray());
+    }
+
+    /** @test */
+    public function testGroupByMultipleAttributes()
+    {
+        $data = new Collection([
+          ['A' => 'foo', 'B' => 'bar',    'C' => 'baz',    'D' => 'thud'],
+          ['A' => 'foo', 'B' => 'garply', 'C' => 'corge',  'D' => 'plugh'],
+          ['A' => 'foo', 'B' => 'bar',    'C' => 'corge',  'D' => 'thud'],
+          ['A' => 'foo', 'B' => 'bar',    'C' => 'corge',  'D' => 'waldo'],
+          ['A' => 'qux', 'B' => 'garply', 'C' => 'xyzzy',  'D' => 'fred'],
+          ['A' => 'qux', 'B' => 'grault', 'C' => 'garply', 'D' => 'quuz'],
+        ]);
+        $result = $data->groupByMultiple(['A', 'B', 'C', 'D']);
+        $expected = [
+          'foo' => [
+            'bar' => [
+              'baz' => [
+                'thud' => [
+                  ['A' => 'foo', 'B' => 'bar',    'C' => 'baz',    'D' => 'thud'],
+                ],
+              ],
+              'corge' => [
+                'thud' => [
+                  ['A' => 'foo', 'B' => 'bar',    'C' => 'corge',  'D' => 'thud'],
+                ],
+                'waldo' => [
+                  ['A' => 'foo', 'B' => 'bar',    'C' => 'corge',  'D' => 'waldo'],
+                ],
+              ],
+            ],
+            'garply' => [
+              'corge' => [
+                'plugh' => [
+                  ['A' => 'foo', 'B' => 'garply', 'C' => 'corge',  'D' => 'plugh'],
+                ],
+              ],
+            ],
+          ],
+          'qux' => [
+            'garply' => [
+              'xyzzy' => [
+                'fred' => [
+                  ['A' => 'qux', 'B' => 'garply', 'C' => 'xyzzy',  'D' => 'fred'],
+                ],
+              ],
+            ],
+            'grault' => [
+              'garply' => [
+                'quuz' => [
+                  ['A' => 'qux', 'B' => 'grault', 'C' => 'garply', 'D' => 'quuz'],
+                ],
+              ],
+            ],
+          ],
+        ];
+        $this->assertEquals($expected, $result->toArray());
+    }
+
+    /** @test */
+    public function testGroupByMultipleAttributePreservingKeys()
+    {
+        $data = new Collection([
+          10 => ['rating' => 1, 'url' => 'a'],
+          20 => ['rating' => 1, 'url' => 'a'],
+          30 => ['rating' => 2, 'url' => 'b'],
+          40 => ['rating' => 2, 'url' => 'a'],
+          50 => ['rating' => 1, 'url' => 'b'],
+          60 => ['rating' => 3, 'url' => 'c'],
+        ]);
+
+        $result = $data->groupByMultiple(['rating', 'url'], true);
+
+        $expected = [
+          1 => [
+            'a' => [
+              10 => ['rating' => 1, 'url' => 'a'],
+              20 => ['rating' => 1, 'url' => 'a'],
+            ],
+            'b' => [
+              50 => ['rating' => 1, 'url' => 'b'],
+            ],
+          ],
+          2 => [
+            'a' => [
+              40 => ['rating' => 2, 'url' => 'a'],
+            ],
+            'b' => [
+              30 => ['rating' => 2, 'url' => 'b'],
+            ],
+          ],
+          3 => [
+            'c' => [
+              60 => ['rating' => 3, 'url' => 'c'],
+            ],
+          ],
+        ];
+
+        $this->assertEquals($expected, $result->toArray());
+    }
+
+    /** @test */
+    public function testGroupByMultipleClosureWhereItemsHaveSingleGroup()
+    {
+        $data = new Collection([
+          ['rating' => 1, 'url' => '1'],
+          ['rating' => 1, 'url' => '1'],
+          ['rating' => 2, 'url' => '2'],
+          ['rating' => 1, 'url' => '3'],
+        ]);
+
+        $callback1 = function ($item) {
+            return $item['rating'];
+        };
+        $callback2 = function ($item) {
+            return $item['url'];
+        };
+        $result = $data->groupByMultiple([$callback1, $callback2]);
+
+        $expected = [
+          1 => [
+            1 => [
+              ['rating' => 1, 'url' => '1'],
+              ['rating' => 1, 'url' => '1'],
+            ],
+            3 => [
+              ['rating' => 1, 'url' => '3'],
+            ],
+          ],
+          2 => [
+            2 => [
+              ['rating' => 2, 'url' => '2'],
+            ],
+          ],
+        ];
+        $this->assertEquals($expected, $result->toArray());
+    }
+
+    /** @test */
+    public function testGroupByMultipleClosureWhereItemsHaveSingleGroupPreservingKeys()
+    {
+        $data = new Collection([
+          10 => ['rating' => 1, 'url' => '1'],
+          20 => ['rating' => 1, 'url' => '1'],
+          30 => ['rating' => 2, 'url' => '2'],
+          40 => ['rating' => 1, 'url' => '3'],
+        ]);
+
+        $callback1 = function ($item) {
+            return $item['rating'];
+        };
+        $callback2 = function ($item) {
+            return $item['url'];
+        };
+        $result = $data->groupByMultiple([$callback1, $callback2], true);
+
+        $expected = [
+          1 => [
+            1 => [
+              10 => ['rating' => 1, 'url' => '1'],
+              20 => ['rating' => 1, 'url' => '1'],
+            ],
+            3 => [
+              40 => ['rating' => 1, 'url' => '3'],
+            ],
+          ],
+          2 => [
+            2 => [
+              30 => ['rating' => 2, 'url' => '2'],
+            ],
+          ],
+        ];
+
+        $this->assertEquals($expected, $result->toArray());
+    }
+
+    /** @test */
+    public function testGroupByMultipleClosureWhereItemsHaveMultipleGroups()
+    {
+        $data = new Collection([
+          ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+          ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']],
+          ['user' => 3, 'roles' => ['Role_1'], 'teams' => ['yellow', 'blue']],
+        ]);
+
+        $callback1 = function ($item) {
+            return $item['roles'];
+        };
+        $callback2 = function ($item) {
+            return $item['teams'];
+        };
+        $result = $data->groupByMultiple([$callback1, $callback2]);
+
+        $expected = [
+          'Role_1' => [
+            'red' => [
+              ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+              ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']],
+            ],
+            'blue' => [
+              ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+              ['user' => 3, 'roles' => ['Role_1'],           'teams' => ['yellow', 'blue']],
+            ],
+            'yellow' => [
+              ['user' => 3, 'roles' => ['Role_1'],           'teams' => ['yellow', 'blue']],
+            ],
+          ],
+          'Role_2' => [
+            'red' => [
+              ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']],
+            ],
+          ],
+          'Role_3' => [
+            'red' => [
+              ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+            ],
+            'blue' => [
+              ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+            ],
+          ],
+        ];
+
+        $this->assertEquals($expected, $result->toArray());
+    }
+
+    /** @test */
+    public function testGroupByMultipleClosureWhereItemsHaveMultipleGroupsPreservingKeys()
+    {
+        $data = new Collection([
+          10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+          20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']],
+          30 => ['user' => 3, 'roles' => ['Role_1'], 'teams' => ['yellow', 'blue']],
+        ]);
+
+        $callback1 = function ($item) {
+            return $item['roles'];
+        };
+        $callback2 = function ($item) {
+            return $item['teams'];
+        };
+        $result = $data->groupByMultiple([$callback1, $callback2], true);
+
+        $expected = [
+          'Role_1' => [
+            'red' => [
+              10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+              20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']],
+            ],
+            'blue' => [
+              10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+              30 => ['user' => 3, 'roles' => ['Role_1'],           'teams' => ['yellow', 'blue']],
+            ],
+            'yellow' => [
+              30 => ['user' => 3, 'roles' => ['Role_1'],           'teams' => ['yellow', 'blue']],
+            ],
+          ],
+          'Role_2' => [
+            'red' => [
+              20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']],
+            ],
+          ],
+          'Role_3' => [
+            'red' => [
+              10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+            ],
+            'blue' => [
+              10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+            ],
+          ],
+        ];
+
+        $this->assertEquals($expected, $result->toArray());
+    }
+}


### PR DESCRIPTION
**Use case**
In the project I am working on I frequently need to create nested structures that are then converted to JSON. This involves some ugly boilerplate code that is needed each time, so my idea is to add a groupByMultiple function to Laravel's Collections that supports grouping multiple times into a nested structure. The new function will be similar to the existing groupBy function.

**Example:**

A | B | C | D
------------ | ------------- | ------------- | -------------
foo | bar | baz | thud
foo | garply | corge | plugh
foo | bar | corge | thud
foo | bar | corge | waldo
qux | garply | xyzzy | fred
qux | grault | garply | quuz

By calling myCollection->groupBy(['A', 'B', 'C', 'D']) the result would become:

* foo
  * bar
    * baz
      * thud [foo, bar, baz, thud]
    * corge
      * thud [foo, bar, corge, thud]
      * waldo [foo, bar, corge, waldo]
  * garply
    * corge
      * plugh [foo, garply, corge, plugh]
* qux
  * garply
    * xyzzy
      * fred [quz, garply, xyzzy, fred]
  * grault
    * garply
      * quuz [qux, grault, garply, quuz]

**Cross compatibility**
The groupByMultiple function is somewhat compatible with groupBy in that it functions in the same way if you pass as first argument something that is not an array, so just like groupBy you can call it with a string or a closure. The function just puts the first argument in an array if it isn't one. If you try to pass a callable as an array, so ["Foo", "Bar"] where Foo::Bar() is a valid method, then of course the groupByMultiple function will just attempt to group on the key "Foo" first and "Bar" second; this is the main incompatibility with groupBy(). Of course you can pass an array with a callable in it, so [["Foo", "Bar"]] or [["Foo", "Bar"], "Baz"] would work just fine. For people already using groupBy, this function will be very easy to switch to.

**Tests**
* I took and modified all existing Collection groupBy unit tests to call groupByMultiple with the same parameters, and they all pass. This ensures the "semi cross-compatibility".
* I also created new unit tests specific to groupByMultiple that are based on all the cases that the existing groupBy unit tests test, but then with multiple fields. They also all pass.


Would love to hear feedback :)