### PR TITLE
Add hasWithValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ $collection->collect('baz', ['Nope']); // Collection(['Nope'])
 
 ### `hasWithValue`
 
-Determines if a given key exists in the collection and has a value.  The following things are considered to be empty:
+Determines if a given key exists in the collection and has a value. The following things are considered to be empty:
 
 - `""` (an empty string)
 - `null`

--- a/README.md
+++ b/README.md
@@ -321,6 +321,38 @@ $collection = collect([
 $collection->collect('baz', ['Nope']); // Collection(['Nope'])
 ```
 
+### `hasWithValue`
+
+Determines if a given key exists in the collection and has a value.  The following things are considered to be empty:
+
+- `""` (an empty string)
+- `null`
+- `[]` (an empty array)
+
+```php
+$collection = collect([
+    'foo' => 'bar',
+    'baz' => null,
+]);
+
+$collection->hasWithValue('foo'); // returns true
+$collection->hasWithValue('baz'); // returns false
+```
+
+It also supports "dot" notation to search deeply nested arrays:
+
+```php
+$collection = collect([
+    'nested' => [
+        'foo' => 'bar',
+        'baz' => null,
+    ],
+]);
+
+$collection->hasWithValue('nested.foo'); // returns true
+$collection->hasWithValue('nested.baz'); // returns false
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/src/macros.php
+++ b/src/macros.php
@@ -298,7 +298,7 @@ if (! Collection::hasMacro('before')) {
     });
 }
 
-if (!Collection::hasMacro('hasWithValue')) {
+if (! Collection::hasMacro('hasWithValue')) {
     /*
      * Check if a given key exists in the collection and has a value
      *
@@ -309,7 +309,7 @@ if (!Collection::hasMacro('hasWithValue')) {
     Collection::macro('hasWithValue', function ($key) {
         $hasKey = array_has($this, $key);
         $value = array_get($this, $key);
-        $hasValue = !empty($value);
+        $hasValue = ! empty($value);
 
         // empty() treats a bunch of valid values as empty, which could actually be valid values
         // Overwrite the behaviour of empty()

--- a/src/macros.php
+++ b/src/macros.php
@@ -297,3 +297,26 @@ if (! Collection::hasMacro('before')) {
         return $this->reverse()->after($currentItem, $fallback);
     });
 }
+
+if (!Collection::hasMacro('hasWithValue')) {
+    /*
+     * Check if a given key exists in the collection and has a value
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    Collection::macro('hasWithValue', function ($key) {
+        $hasKey = array_has($this, $key);
+        $value = array_get($this, $key);
+        $hasValue = !empty($value);
+
+        // empty() treats a bunch of valid values as empty, which could actually be valid values
+        // Overwrite the behaviour of empty()
+        if ($value === false || is_numeric($value)) {
+            $hasValue = true;
+        }
+
+        return $hasKey && $hasValue;
+    });
+}

--- a/tests/HasWithValueTest.php
+++ b/tests/HasWithValueTest.php
@@ -42,7 +42,7 @@ class HasWithValueTest extends TestCase
     }
 
     /** @test */
-    function can_tell_if_key_does_not_exists_in_collection_or_has_no_value()
+    function can_tell_if_key_does_not_exist_in_collection_or_has_no_value()
     {
         $data = new Collection([
             'null' => null,

--- a/tests/HasWithValueTest.php
+++ b/tests/HasWithValueTest.php
@@ -57,5 +57,6 @@ class HasWithValueTest extends TestCase
         $this->assertFalse($data->hasWithValue('string'));
         $this->assertFalse($data->hasWithValue('array'));
         $this->assertFalse($data->hasWithValue('nested.null'));
+        $this->assertFalse($data->hasWithValue('nope'));
     }
 }

--- a/tests/HasWithValueTest.php
+++ b/tests/HasWithValueTest.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Collection;
 class HasWithValueTest extends TestCase
 {
     /** @test */
-    function can_tell_if_key_exists_in_collection_and_has_a_value()
+    public function can_tell_if_key_exists_in_collection_and_has_a_value()
     {
         $data = new Collection([
             'string' => 'foo',
@@ -42,7 +42,7 @@ class HasWithValueTest extends TestCase
     }
 
     /** @test */
-    function can_tell_if_key_does_not_exist_in_collection_or_has_no_value()
+    public function can_tell_if_key_does_not_exist_in_collection_or_has_no_value()
     {
         $data = new Collection([
             'null' => null,

--- a/tests/HasWithValueTest.php
+++ b/tests/HasWithValueTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test;
+
+use Illuminate\Support\Collection;
+
+class HasWithValueTest extends TestCase
+{
+    /** @test */
+    function can_tell_if_key_exists_in_collection_and_has_a_value()
+    {
+        $data = new Collection([
+            'string' => 'foo',
+            'integer' => 0,
+            'decimal' => 0.0,
+            'zero' => '0',
+            'true' => true,
+            'false' => false,
+            'function' => function () {
+            },
+            'array' => [
+                'test',
+            ],
+            'nested' => [
+                'array' => [
+                    'string' => 'foo',
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($data->hasWithValue('string'));
+        $this->assertTrue($data->hasWithValue('integer'));
+        $this->assertTrue($data->hasWithValue('decimal'));
+        $this->assertTrue($data->hasWithValue('function'));
+        $this->assertTrue($data->hasWithValue('zero'));
+        $this->assertTrue($data->hasWithValue('true'));
+        $this->assertTrue($data->hasWithValue('false'));
+        $this->assertTrue($data->hasWithValue('array'));
+        $this->assertTrue($data->hasWithValue('nested'));
+        $this->assertTrue($data->hasWithValue('nested.array'));
+        $this->assertTrue($data->hasWithValue('nested.array.string'));
+    }
+
+    /** @test */
+    function can_tell_if_key_does_not_exists_in_collection_or_has_no_value()
+    {
+        $data = new Collection([
+            'null' => null,
+            'string' => '',
+            'array' => [],
+            'nested' => [
+                'null' => null,
+            ],
+        ]);
+
+        $this->assertFalse($data->hasWithValue('null'));
+        $this->assertFalse($data->hasWithValue('string'));
+        $this->assertFalse($data->hasWithValue('array'));
+        $this->assertFalse($data->hasWithValue('nested.null'));
+    }
+}


### PR DESCRIPTION
I often run into times where I need to both check the existence of a key in a collection & whether that key has a value. Because `has()` only checks for the existence of the key, I find myself having to write code like this:

```php
if ($collection->has('field') && !empty($collection->get('field')) {
    $model->field = $collection->get('field');
}
```

I run into this myself when using `collect($request->only('field'));`. If `field` is not present in the request, it will get set in the collection with a `null` value. Which means I cannot use `has` on its own.

I wrote a small macro to make this check a little easier. Instead, we can write:

```php
if ($collection->hasWithValue('field')) {
    $model->field = $collection->get('field');
}
```

The following things are considered to be empty:

- `""` (an empty string)
- `null`
- `[]` (an empty array)

Note that `false`, `0` etc are considered non-empty values for this macro (unlike `empty()`). 