### PR TITLE
Add tail, eachCons, sliceBefore and chunkBy

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,43 @@ Extract keys from a collection. This is very similar to `only`, with two key dif
 [$name, $role] = collect($user)->extract('name', 'role.name');
 ```
 
+### `tail`
+
+Extract the tail from a collection. So everything except the first element.
+It's a shorthand for `slice(1)->values()`, but nevertheless very handy.
+
+```php
+collect([1, 2, 3))->tail(); // return Collection([2, 3])
+```
+
+### `eachCons`
+
+Get the following consecutive neighbours in a collection from a given chunk size
+
+```php
+collect([1, 2, 3, 4])->eachCons(2); // return Collection([[1, 2], [2, 3], [3, 4]])
+```
+
+### `sliceBefore`
+
+Slice the values out from a collection before the given callback is true
+
+```php
+collect([20, 51, 10, 50, 66])->sliceBefore(function($item) {
+    return $item > 50;
+}); // return Collection([[20],[51, 10]])
+```
+
+### `chunkBy`
+
+Chunks the values from a collection into groups as long the given callback is true
+
+```php
+collect(['A', 'A', 'B', 'A'])->chunkBy(function($item) {
+    return $item == 'A';
+}); // return Collection([['A', 'A'],['B'], ['A']])
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/tests/ChunkByTest.php
+++ b/tests/ChunkByTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test;
+
+use Illuminate\Support\Collection;
+
+class ChunkByTest extends TestCase
+{
+    /** @test */
+    public function it_provides_chunk_by_macro()
+    {
+        $this->assertTrue(Collection::hasMacro('chunkBy'));
+    }
+
+    /** @test */
+    public function it_can_chunk_the_collection_with_a_given_callback()
+    {
+        $collection = new Collection(['A', 'A', 'A', 'B', 'B', 'A', 'A', 'C', 'B', 'B', 'A']);
+
+        $chunkedBy = $collection->chunkBy(function ($item) {
+            return $item == 'A';
+        });
+
+        $expected = [
+            ['A', 'A', 'A'],
+            ['B', 'B'],
+            ['A', 'A'],
+            ['C', 'B', 'B'],
+            ['A'],
+        ];
+
+        $this->assertEquals($expected, $chunkedBy->toArray());
+    }
+}

--- a/tests/EachConsTest.php
+++ b/tests/EachConsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test;
+
+use Illuminate\Support\Collection;
+
+class EachConsTest extends TestCase
+{
+    /** @test */
+    public function it_provides_each_cons_macro()
+    {
+        $this->assertTrue(Collection::hasMacro('eachCons'));
+    }
+
+    /** @test */
+    public function it_can_chunk_the_collection_into_consecutive_pairs_of_values_by_a_given_chunk_size_of_two()
+    {
+        $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
+
+        $sliced = $collection->eachCons(2);
+
+        $expected = [
+            [1, 2],
+            [2, 3],
+            [3, 4],
+            [4, 5],
+            [5, 6],
+            [6, 7],
+            [7, 8],
+        ];
+
+        $this->assertEquals($expected, $sliced->toArray());
+    }
+
+    /** @test */
+    public function it_can_chunk_the_collection_into_consecutive_pairs_of_values_by_a_given_chunk_size_or_greater()
+    {
+        $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
+
+        $sliced = $collection->eachCons(4);
+
+        $expected = [
+            [1, 2, 3, 4],
+            [2, 3, 4, 5],
+            [3, 4, 5, 6],
+            [4, 5, 6, 7],
+            [5, 6, 7, 8],
+        ];
+
+        $this->assertEquals($expected, $sliced->toArray());
+    }
+}

--- a/tests/SliceBeforeTest.php
+++ b/tests/SliceBeforeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test;
+
+use Illuminate\Support\Collection;
+
+class SliceBeforeTest extends TestCase
+{
+    /** @test */
+    public function it_provides_slice_before_macro()
+    {
+        $this->assertTrue(Collection::hasMacro('sliceBefore'));
+    }
+
+    /** @test */
+    public function it_can_slice_before_the_collection_with_a_given_callback()
+    {
+        $collection = new Collection([10, 34, 51, 17, 47, 64, 9, 44, 20, 59, 66, 77]);
+
+        $sliced = $collection->sliceBefore(function ($number) {
+            return $number > 50;
+        });
+
+        $expected = [
+            [10, 34],
+            [51, 17, 47],
+            [64, 9, 44, 20],
+            [59],
+            [66],
+            [77],
+        ];
+
+        $this->assertEquals($expected, $sliced->toArray());
+    }
+}

--- a/tests/TailTest.php
+++ b/tests/TailTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test;
+
+use Illuminate\Support\Collection;
+
+class TailTest extends TestCase
+{
+    /** @test */
+    public function it_provides_tail_macro()
+    {
+        $this->assertTrue(Collection::hasMacro('tail'));
+    }
+
+    /** @test */
+    public function it_can_tail_the_collection_with_numbers()
+    {
+        $collection = new Collection([10, 34, 51, 17, 47, 64, 9, 44, 20, 59, 66, 77]);
+
+        $tail = $collection->tail();
+
+        $expected = [
+          34,
+          51,
+          17,
+          47,
+          64,
+          9,
+          44,
+          20,
+          59,
+          66,
+          77
+        ];
+
+        $this->assertEquals($expected, $tail->toArray());
+    }
+
+    /** @test */
+    public function it_can_tail_the_collection_with_strings()
+    {
+        $collection = new Collection(['1', '2', '3', 'Hello', 'Spatie']);
+
+        $tail = $collection->tail();
+
+        $expected = [
+            '2',
+            '3',
+            'Hello',
+            'Spatie'
+        ];
+
+        $this->assertEquals($expected, $tail->toArray());
+    }
+}


### PR DESCRIPTION
as mentioned in #59.

For older versions the `tail()` methods needs to omit the `->values()` call. Think it was introduced in L5.2?