### PR TITLE
Add support for preserve original array keys in 4 recently added methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,8 @@ Extract keys from a collection. This is very similar to `only`, with two key dif
 ### `tail`
 
 Extract the tail from a collection. So everything except the first element.
-It's a shorthand for `slice(1)->values()`, but nevertheless very handy.
+It's a shorthand for `slice(1)->values()`. If the optional parameter `$preserveKeys` as `true` is passed, it will
+preserve the keys and fallback to `slice(1)`.
 
 ```php
 collect([1, 2, 3))->tail(); // return collect([2, 3])
@@ -463,7 +464,8 @@ collect([1, 2, 3))->tail(); // return collect([2, 3])
 
 ### `eachCons`
 
-Get the following consecutive neighbours in a collection from a given chunk size.
+Get the following consecutive neighbours in a collection from a given chunk size. 
+If the optional parameter `$preserveKeys` as `true` is passed, it will preserve the original keys.
 
 ```php
 collect([1, 2, 3, 4])->eachCons(2); // return collect([[1, 2], [2, 3], [3, 4]])
@@ -472,16 +474,18 @@ collect([1, 2, 3, 4])->eachCons(2); // return collect([[1, 2], [2, 3], [3, 4]])
 ### `sliceBefore`
 
 Slice the values out from a collection before the given callback is true.
+If the optional parameter `$preserveKeys` as `true` is passed, it will preserve the original keys.
 
 ```php
 collect([20, 51, 10, 50, 66])->sliceBefore(function($item) {
     return $item > 50;
-}); // return collect([[20],[51, 10]])
+}); // return collect([[20],[51, 10, 50], [66])
 ```
 
 ### `chunkBy`
 
 Chunks the values from a collection into groups as long the given callback is true.
+If the optional parameter `$preserveKeys` as `true` is passed, it will preserve the original keys.
 
 ```php
 collect(['A', 'A', 'B', 'A'])->chunkBy(function($item) {

--- a/tests/ChunkByTest.php
+++ b/tests/ChunkByTest.php
@@ -31,4 +31,64 @@ class ChunkByTest extends TestCase
 
         $this->assertEquals($expected, $chunkedBy->toArray());
     }
+
+    /** @test */
+    public function it_can_chunk_the_collection_with_a_given_callback_with_associative_keys()
+    {
+        $collection = new Collection(['a' => 'A', 'b' => 'A', 'c' => 'A', 'd' => 'B', 'e' => 'B', 'f' => 'A', 'g' => 'A', 'h' => 'C', 'i' => 'B', 'j' => 'B', 'k' => 'A']);
+
+        $chunkedBy = $collection->chunkBy(function ($item) {
+            return $item == 'A';
+        });
+
+        $expected = [
+            ['A', 'A', 'A'],
+            ['B', 'B'],
+            ['A', 'A'],
+            ['C', 'B', 'B'],
+            ['A'],
+        ];
+
+        $this->assertEquals($expected, $chunkedBy->toArray());
+    }
+
+    /** @test */
+    public function it_can_chunk_the_collection_with_a_given_callback_and_preserve_the_original_keys()
+    {
+        $collection = new Collection(['A', 'A', 'A', 'B', 'B', 'A', 'A', 'C', 'B', 'B', 'A']);
+
+        $chunkedBy = $collection->chunkBy(function ($item) {
+            return $item == 'A';
+        }, true);
+
+        $expected = [
+            [0 => 'A', 1 => 'A', 2 => 'A'],
+            [3 => 'B', 4 => 'B'],
+            [5 => 'A', 6 => 'A'],
+            [7 => 'C', 8 => 'B', 9 => 'B'],
+            [10 => 'A'],
+        ];
+
+        $this->assertEquals($expected, $chunkedBy->toArray());
+    }
+
+    /** @test */
+    public function it_can_chunk_the_collection_with_a_given_callback_with_associative_keys_and_preserve_the_original_keys()
+    {
+        $collection = new Collection(['a' => 'A', 'b' => 'A', 'c' => 'A', 'd' => 'B', 'e' => 'B', 'f' => 'A', 'g' => 'A', 'h' => 'C', 'i' => 'B', 'j' => 'B', 'k' => 'A']);
+
+        $chunkedBy = $collection->chunkBy(function ($item) {
+            return $item == 'A';
+        }, true);
+
+        $expected = [
+            ['a' => 'A', 'b' => 'A', 'c' => 'A'],
+            ['d' => 'B', 'e' => 'B'],
+            ['f' => 'A', 'g' => 'A'],
+            ['h' => 'C', 'i' => 'B', 'j' => 'B'],
+            ['k' => 'A'],
+        ];
+
+        $this->assertEquals($expected, $chunkedBy->toArray());
+    }
 }

--- a/tests/EachConsTest.php
+++ b/tests/EachConsTest.php
@@ -49,4 +49,24 @@ class EachConsTest extends TestCase
 
         $this->assertEquals($expected, $sliced->toArray());
     }
+
+    /** @test */
+    public function it_can_chunk_the_collection_into_consecutive_pairs_of_values_by_a_given_chunk_size_of_two_with_preserving_the_original_keys()
+    {
+        $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
+
+        $sliced = $collection->eachCons(2, true);
+
+        $expected = [
+            [0 => 1, 1 => 2],
+            [1 => 2, 2 => 3],
+            [2 => 3, 3 => 4],
+            [3 => 4, 4 => 5],
+            [4 => 5, 5 => 6],
+            [5 => 6, 6 => 7],
+            [6 => 7, 7 => 8],
+        ];
+
+        $this->assertEquals($expected, $sliced->toArray());
+    }
 }

--- a/tests/SliceBeforeTest.php
+++ b/tests/SliceBeforeTest.php
@@ -32,4 +32,112 @@ class SliceBeforeTest extends TestCase
 
         $this->assertEquals($expected, $sliced->toArray());
     }
+
+    /** @test */
+    public function it_can_slice_before_the_collection_with_a_given_callback_with_preserving_the_original_keys()
+    {
+        $collection = new Collection([10, 34, 51, 17, 47, 64, 9, 44, 20, 59, 66, 77]);
+
+        $sliced = $collection->sliceBefore(function ($number) {
+            return $number > 50;
+        }, true);
+
+        $expected = [
+            [0 => 10, 1 => 34],
+            [2 => 51, 3 => 17, 4 => 47],
+            [5 => 64, 6 => 9, 7 => 44, 8 => 20],
+            [9 => 59],
+            [10 => 66],
+            [11 => 77],
+        ];
+
+        $toArray = $sliced->toArray();
+        $this->assertEquals($expected, $toArray);
+    }
+
+    /** @test */
+    public function it_can_slice_before_the_collection_with_complex_data_with_a_given_callback_without_preserving_the_original_keys()
+    {
+        $collection = new Collection([10, [34, 51], [17], 47, [64, 9], 44, [20], [59], [66], 77]);
+
+        $sliced = $collection->sliceBefore(function ($item) {
+            return is_array($item);
+        });
+
+        $expected = [
+            [10],
+            [[34, 51]],
+            [[17], 47],
+            [[64, 9], 44],
+            [[20]],
+            [[59]],
+            [[66], 77],
+        ];
+
+        $this->assertEquals($expected, $sliced->toArray());
+    }
+
+    /** @test */
+    public function it_can_slice_before_the_collection_with_complex_data_with_a_given_callback_with_preserving_the_original_keys()
+    {
+        $collection = new Collection([10, [34, 51], [17], 47, [64, 9], 44, [20], [59], [66], 77]);
+
+        $sliced = $collection->sliceBefore(function ($item) {
+            return is_array($item);
+        }, true);
+
+        $expected = [
+            [0 => 10],
+            [1 => [34, 51]],
+            [2 => [17], 3 => 47],
+            [4 => [64, 9], 5 => 44],
+            [6 => [20]],
+            [7 => [59]],
+            [8 => [66], 9 => 77],
+        ];
+
+        $this->assertEquals($expected, $sliced->toArray());
+    }
+
+    /** @test */
+    public function it_can_slice_before_the_collection_with_a_given_callback_without_preserving_the_original_associative_keys()
+    {
+        $collection = new Collection(['a' => 10, 'b' => 34, 'c' => 51, 'd' => 17, 'e' => 47, 'f' => 64, 'g' => 9, 'h' => 44, 'i' => 20, 'j' => 59, 'k' => 66, 'l' => 77]);
+
+        $sliced = $collection->sliceBefore(function ($number) {
+            return $number > 50;
+        });
+
+        $expected = [
+            [10, 34],
+            [51, 17, 47],
+            [64, 9, 44, 20],
+            [59],
+            [66],
+            [77],
+        ];
+
+        $this->assertEquals($expected, $sliced->toArray());
+    }
+
+    /** @test */
+    public function it_can_slice_before_the_collection_with_a_given_callback_with_preserving_the_original_associative_keys()
+    {
+        $collection = new Collection(['a' => 10, 'b' => 34, 'c' => 51, 'd' => 17, 'e' => 47, 'f' => 64, 'g' => 9, 'h' => 44, 'i' => 20, 'j' => 59, 'k' => 66, 'l' => 77]);
+
+        $sliced = $collection->sliceBefore(function ($number) {
+            return $number > 50;
+        }, true);
+
+        $expected = [
+            ['a' => 10, 'b' => 34],
+            ['c' => 51, 'd' => 17, 'e' => 47],
+            ['f' => 64, 'g' => 9, 'h' => 44, 'i' => 20],
+            ['j' => 59],
+            ['k' => 66],
+            ['l' => 77],
+        ];
+
+        $this->assertEquals($expected, $sliced->toArray());
+    }
 }

--- a/tests/TailTest.php
+++ b/tests/TailTest.php
@@ -13,31 +13,31 @@ class TailTest extends TestCase
     }
 
     /** @test */
-    public function it_can_tail_the_collection_with_numbers()
+    public function it_can_tail_the_collection_with_numbers_without_preserving_the_keys()
     {
         $collection = new Collection([10, 34, 51, 17, 47, 64, 9, 44, 20, 59, 66, 77]);
 
         $tail = $collection->tail();
 
         $expected = [
-          34,
-          51,
-          17,
-          47,
-          64,
-          9,
-          44,
-          20,
-          59,
-          66,
-          77,
+            34,
+            51,
+            17,
+            47,
+            64,
+            9,
+            44,
+            20,
+            59,
+            66,
+            77,
         ];
 
         $this->assertEquals($expected, $tail->toArray());
     }
 
     /** @test */
-    public function it_can_tail_the_collection_with_strings()
+    public function it_can_tail_the_collection_with_strings_without_preserving_the_keys()
     {
         $collection = new Collection(['1', '2', '3', 'Hello', 'Spatie']);
 
@@ -48,6 +48,47 @@ class TailTest extends TestCase
             '3',
             'Hello',
             'Spatie',
+        ];
+
+        $this->assertEquals($expected, $tail->toArray());
+    }
+
+    /** @test */
+    public function it_can_tail_the_collection_with_numbers_with_preserving_the_keys()
+    {
+        $collection = new Collection([10, 34, 51, 17, 47, 64, 9, 44, 20, 59, 66, 77]);
+
+        $tail = $collection->tail(true);
+
+        $expected = [
+            1 => 34,
+            2 => 51,
+            3 => 17,
+            4 => 47,
+            5 => 64,
+            6 => 9,
+            7 => 44,
+            8 => 20,
+            9 => 59,
+            10 => 66,
+            11 => 77,
+        ];
+
+        $this->assertEquals($expected, $tail->toArray());
+    }
+
+    /** @test */
+    public function it_can_tail_the_collection_with_strings()
+    {
+        $collection = new Collection(['1', '2', '3', 'Hello', 'Spatie']);
+
+        $tail = $collection->tail(true);
+
+        $expected = [
+            1 => '2',
+            2 => '3',
+            3 => 'Hello',
+            4 => 'Spatie',
         ];
 
         $this->assertEquals($expected, $tail->toArray());


### PR DESCRIPTION
- tail
- eachCons
- sliceBefore
- chunkBy

have all now an optional parameter to preserve the keys. Needed that feature myself in some use cases. So that the parameter is optional, it shouldn't be a breaking change.

Refactoring the `sliceBefore` method was quite tricky to preserve the keys. I'm not so satisfied with the implementation. Maybe someone else can streamline the method a bit?