### PR TITLE
Added new macro rotate to rotate the items in the collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,21 @@ Collection::withSize(1)->toArray(); // return [1];
 Collection::withSize(5)->toArray(); // return [1,2,3,4,5];
 ```
 
+### `rotate`
+
+Rotate the items in the collection with given offset
+
+```php
+$collection = collect([1, 2, 3, 4, 5, 6]);
+
+$rotate = $collection->rotate(1);
+
+$rotate->toArray();
+
+// [2, 3, 4, 5, 6, 1]
+```
+
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/src/macros/rotate.php
+++ b/src/macros/rotate.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Support\Collection;
+
+/*
+ * Rotate the items in the collection with given offset
+ *
+ * @param int $offset
+ *
+ * @return \Illuminate\Support\Collection
+ */
+Collection::macro('rotate', function (int $offset): Collection {
+    if ($this->isEmpty()) {
+        return new static;
+    }
+
+    $count = $this->count();
+
+    $offset %= $count;
+
+    if ($offset < 0) {
+        $offset += $count;
+    }
+
+    return new static($this->slice($offset)->merge($this->take($offset)));
+});

--- a/tests/RotateTest.php
+++ b/tests/RotateTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test;
+
+use Illuminate\Support\Collection;
+
+class RotateTest extends TestCase
+{
+    /** @test */
+    public function it_provides_rotate_macro()
+    {
+        $this->assertTrue(Collection::hasMacro('rotate'));
+    }
+
+    /** @test */
+    public function it_can_return_empty_collection_if_given_empty_collecton()
+    {
+        $collection = new Collection([]);
+        $this->assertCount(0, $collection->rotate(2)->toArray());
+    }  
+
+    /** @test */
+    public function it_can_return_same_collection_if_given_zero_offset()
+    {
+        $collection = new Collection([1, 2, 3, 4, 5, 6]);
+        $this->assertEquals([1, 2, 3, 4, 5, 6], $collection->rotate(0)->toArray());
+    }  
+
+    /** @test */
+    public function it_can_rotate_the_collection_with_offset()
+    {
+        $collection = new Collection([1, 2, 3, 4, 5, 6]);
+        $this->assertEquals([3, 4, 5, 6, 1, 2], $collection->rotate(2)->toArray());
+    }
+
+    /** @test */
+    public function it_can_rotate_the_collection_with_negative_offset()
+    {
+        $collection = new Collection([1, 2, 3, 4, 5, 6]);
+        $this->assertEquals([5, 6, 1, 2, 3, 4], $collection->rotate(-2)->toArray());
+    }
+
+    /** @test */
+    public function it_can_rotate_the_collection_with_offset_with_keys()
+    {
+        $collection = new Collection(['first' => 1, 'second' => 2, 'third' => 3, 'fourth' => 4, 'fifth' => 5]);
+        $this->assertEquals(['fourth' => 4, 'fifth' => 5, 'first' => 1, 'second' => 2, 'third' => 3], $collection->rotate(3)->toArray());
+    }
+
+    /** @test */
+    public function it_can_rotate_the_collection_with_nagative_offset_with_keys()
+    {
+        $collection = new Collection(['first' => 1, 'second' => 2, 'third' => 3, 'fourth' => 4, 'fifth' => 5]);
+        $this->assertEquals(['third' => 3, 'fourth' => 4, 'fifth' => 5, 'first' => 1, 'second' => 2], $collection->rotate(-3)->toArray());
+    }
+
+}


### PR DESCRIPTION
This is the PR for adding the new macro rotate.

`rotate()`

Roate the items in the given collection

```
$collection = collect([1, 2, 3, 4, 5, 6]);

$rotate = $collection->rotate(1);

$rotate->all();

// [2, 3, 4, 5, 6, 1]
```
```
$collection = collect([ "one" => 1, "two" => 2, "three" => 3, "four" => 4]);

$rotate = $collection->rotate(2);

$rotate->all();

// [  "three" => 3, "four" => 4, "one" => 1, "two" => 2]
```

```
$collection = collect([ "one" => 1, "two" => 2, "three" => 3, "four" => 4, 'five' => 5]);

$rotate = $collection->rotate(-3);

$rotate->all();

// [ 'three' => 3, 'four' => 4, 'five' => 5, 'one' => 1, 'two' => 2]
```
