### PR TITLE
Allow a single array to be transposed.

### DIFF
--- a/src/macros/transpose.php
+++ b/src/macros/transpose.php
@@ -10,18 +10,17 @@ use Illuminate\Support\Collection;
  * @throws \LengthException
  */
 Collection::macro('transpose', function (): Collection {
-    $values = $this->values();
-
     $expectedLength = count($this->first());
-    $diffLength = count(array_intersect_key(...$values));
 
-    if ($expectedLength !== $diffLength) {
-        throw new LengthException("Element's length must be equal.");
-    }
+    array_walk($this->items, function ($row) use ($expectedLength) {
+        if (count($row) !== $expectedLength) {
+            throw new \LengthException("Element's length must be equal.");
+        }
+    });
 
     $items = array_map(function (...$items) {
         return new static($items);
-    }, ...$values);
+    }, ...$this->values());
 
     return new static($items);
 });

--- a/tests/TransposeTest.php
+++ b/tests/TransposeTest.php
@@ -56,4 +56,20 @@ class TransposeTest extends TestCase
 
         $this->assertEquals($expected, $collection->transpose());
     }
+
+    /** @test */
+    public function it_can_transpose_a_single_row_array()
+    {
+        $collection = new Collection([
+            ['11', '12', '13'],
+        ]);
+
+        $expected = new Collection([
+            new Collection(['11']),
+            new Collection(['12']),
+            new Collection(['13']),
+        ]);
+
+        $this->assertEquals($expected, $collection->transpose());
+    }
 }


### PR DESCRIPTION
The previous implementation used `array_intersect_key` to detect the number of elements in each "row" and ensure they were all equal before transposing.

The trouble with this is that it required a minimum of 2 "rows" (arrays) to check otherwise an `array_intersect_key(): at least 2 parameters are required, 1 given` error was thrown.

This PR takes a stab at trying to get around this issue, as cleanly as I could, whilst maintaining the check that all "rows" should have the same number of elements before a transpose is allowed to take place. Tests included.

I needed this functionality because whilst looping over a batch of results in a collection, 1 or 2 of them happened to be single array and the next `transpose` operation was blowing up because of this.

I could have broken out of the collection pipeline and attempted a manual map if the number of rows was equal to 1 - but man, that was ugly!