### PR TITLE
Updated to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "illuminate/view": "~5.5.0"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.5",
+        "mockery/mockery": "^1.0",
         "orchestra/database": "~3.5.0",
         "orchestra/testbench": "~3.5.0",
         "phpunit/phpunit": "^6.2"


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).