### PR TITLE
✨ Added sortByDate and sortByDateDesc macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The package will automatically register itself.
 - [`sectionBy`](#sectionby)
 - [`simplePaginate`](#simplepaginate)
 - [`sliceBefore`](#slicebefore)
+- [`sortByDate`](#sortbydate)
+- [`sortByDateDesc`](#sortbydatedesc)
 - [`tail`](#tail)
 - [`toPairs`](#topairs)
 - [`transpose`](#transpose)
@@ -419,6 +421,54 @@ collect([20, 51, 10, 50, 66])->sliceBefore(function($item) {
     return $item > 50;
 }); // return collect([[20],[51, 10, 50], [66])
 ```
+
+### `sortByDate`
+
+Sort the values in a collection by a datetime value.
+
+To sort a simple list of dates, call the method without passing any arguments to it.
+
+```php
+collect(['2018-01-04', '1995-07-15', '2000-01-01'])->sortByDate();
+// return collect(['1995-07-15', '2000-01-01', '2018-01-04'])
+```
+
+To sort a collection where the date is in a specific key, pass the key name when calling the method.
+
+```php
+collect([
+    ['date' => '2018-01-04', 'name' => 'Banana'],
+    ['date' => '1995-07-15', 'name' => 'Apple'],
+    ['date' => '2000-01-01', 'name' => 'Orange']
+])->sortByDate('date')
+  ->all();
+
+// [
+//    ['date' => '1995-07-15', 'name' => 'Apple'],
+//    ['date' => '2000-01-01', 'name' => 'Orange'],
+//    ['date' => '2018-01-04', 'name' => 'Banana']
+// ]
+```
+
+Additionally, you can pass a callback to the method to choose more precisely what is sorted.
+
+```php
+$users = User::all();
+
+$users->sortByDate(function(User $user) {
+    return $user->created_at;
+})->toArray();
+
+// [
+//    ['id' => 12, 'username' => 'spatie', 'created_at' => '1995-07-15'],
+//    ['id' => 15, 'username' => 'taylor', 'created_at' => '2000-01-01'],
+//    ['id' => 2, 'username' => 'jeffrey', 'created_at' => '2018-01-04']
+// ]
+```
+
+### `sortByDateDesc`
+
+This method has the same signature as the `sortByDate` method, but will sort the collection in the opposite order.
 
 ### `tail`
 

--- a/src/macros/sortByDate.php
+++ b/src/macros/sortByDate.php
@@ -11,14 +11,12 @@ use Illuminate\Support\Collection;
  * @return Collection
  */
 Collection::macro('sortByDate', function ($key = null) {
-
-    return $this->sortBy(function($item) use ($key) {
-
-        if (is_callable($key) && !is_string($key)) {
+    return $this->sortBy(function ($item) use ($key) {
+        if (is_callable($key) && ! is_string($key)) {
             return $key($item);
         }
 
-        $date = $key === null ? $item : $item[$key];
+        $date = null === $key ? $item : $item[$key];
 
         if ($date instanceof Carbon) {
             return $date->getTimestamp();
@@ -26,10 +24,10 @@ Collection::macro('sortByDate', function ($key = null) {
 
         try {
             return Carbon::parse($date)->getTimestamp();
-        } catch (Exception $e) {}
+        } catch (Exception $e) {
+        }
 
         return 0;
-
     })->values();
 });
 

--- a/src/macros/sortByDate.php
+++ b/src/macros/sortByDate.php
@@ -1,0 +1,45 @@
+<?php
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+/*
+ * Sort the values in a collection by a datetime value.
+ *
+ * @param mixed $key
+ *
+ * @return Collection
+ */
+Collection::macro('sortByDate', function ($key = null) {
+
+    return $this->sortBy(function($item) use ($key) {
+
+        if (is_callable($key) && !is_string($key)) {
+            return $key($item);
+        }
+
+        $date = $key === null ? $item : $item[$key];
+
+        if ($date instanceof Carbon) {
+            return $date->getTimestamp();
+        }
+
+        try {
+            return Carbon::parse($date)->getTimestamp();
+        } catch (Exception $e) {}
+
+        return 0;
+
+    })->values();
+});
+
+/*
+ * Sort the values in a collection by a datetime value in reversed order.
+ *
+ * @param mixed $key
+ *
+ * @return mixed
+ */
+Collection::macro('sortByDateDesc', function ($key = null) {
+    return $this->sortByDate($key)->reverse();
+});

--- a/tests/SortByDateTest.php
+++ b/tests/SortByDateTest.php
@@ -13,7 +13,7 @@ class SortByDateTest extends TestCase
         $data = new Collection([
             '2018-01-04',
             '1995-07-15',
-            '2000-01-01'
+            '2000-01-01',
         ]);
 
         $this->assertEquals('1995-07-15', $data->sortByDate()->first());
@@ -26,7 +26,7 @@ class SortByDateTest extends TestCase
         $data = new Collection([
             '2018-01-04',
             '1995-07-15',
-            '2000-01-01'
+            '2000-01-01',
         ]);
 
         $this->assertEquals('2018-01-04', $data->sortByDateDesc()->first());
@@ -40,7 +40,7 @@ class SortByDateTest extends TestCase
             '2018-01-04',
             '1995-07-15',
             'Taylor Otwell',
-            '2000-01-01'
+            '2000-01-01',
         ]);
 
         $this->assertEquals('Taylor Otwell', $data->sortByDate()->first());
@@ -53,7 +53,7 @@ class SortByDateTest extends TestCase
         $data = new Collection([
             ['date' => '2018-01-04', 'name' => 'Banana'],
             ['date' => '1995-07-15', 'name' => 'Apple'],
-            ['date' => '2000-01-01', 'name' => 'Orange']
+            ['date' => '2000-01-01', 'name' => 'Orange'],
         ]);
 
         $this->assertEquals('Apple', $data->sortByDate('date')->first()['name']);
@@ -66,7 +66,7 @@ class SortByDateTest extends TestCase
         $data = new Collection([
             Carbon::parse('2018-01-04'),
             Carbon::parse('1995-07-15'),
-            Carbon::parse('2000-01-01')
+            Carbon::parse('2000-01-01'),
         ]);
 
         $this->assertEquals('1995-07-15', $data->sortByDate()->first()->format('Y-m-d'));
@@ -81,26 +81,26 @@ class SortByDateTest extends TestCase
                 'name' => 'Banana',
                 'dates' => [
                     'from' => '2018-01-04',
-                    'to' => '2019-01-01'
-                ]
+                    'to' => '2019-01-01',
+                ],
             ],
             [
                 'name' => 'Apple',
                 'dates' => [
                     'from' => '1995-07-15',
-                    'to' => '2019-06-12'
-                ]
+                    'to' => '2019-06-12',
+                ],
             ],
             [
                 'name' => 'Orange',
                 'dates' => [
                     'from' => '2000-01-01',
-                    'to' => '2020-04-31'
-                ]
-            ]
+                    'to' => '2020-04-31',
+                ],
+            ],
         ]);
 
-        $this->assertEquals('Apple', $data->sortByDate(function($item) {
+        $this->assertEquals('Apple', $data->sortByDate(function ($item) {
             return $item['dates']['from'];
         })->first()['name']);
     }

--- a/tests/SortByDateTest.php
+++ b/tests/SortByDateTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test;
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class SortByDateTest extends TestCase
+{
+    /** @test */
+    public function it_sorts_dates_in_a_list()
+    {
+        $data = new Collection([
+            '2018-01-04',
+            '1995-07-15',
+            '2000-01-01'
+        ]);
+
+        $this->assertEquals('1995-07-15', $data->sortByDate()->first());
+        $this->assertEquals('2018-01-04', $data->sortByDate()->last());
+    }
+
+    /** @test */
+    public function it_sorts_dates_in_a_list_in_descending_order()
+    {
+        $data = new Collection([
+            '2018-01-04',
+            '1995-07-15',
+            '2000-01-01'
+        ]);
+
+        $this->assertEquals('2018-01-04', $data->sortByDateDesc()->first());
+        $this->assertEquals('1995-07-15', $data->sortByDateDesc()->last());
+    }
+
+    /** @test */
+    public function it_will_treat_a_non_date_value_as_a_timestamp_of_zero()
+    {
+        $data = new Collection([
+            '2018-01-04',
+            '1995-07-15',
+            'Taylor Otwell',
+            '2000-01-01'
+        ]);
+
+        $this->assertEquals('Taylor Otwell', $data->sortByDate()->first());
+        $this->assertEquals('2018-01-04', $data->sortByDate()->last());
+    }
+
+    /** @test */
+    public function it_sorts_dates_as_a_key()
+    {
+        $data = new Collection([
+            ['date' => '2018-01-04', 'name' => 'Banana'],
+            ['date' => '1995-07-15', 'name' => 'Apple'],
+            ['date' => '2000-01-01', 'name' => 'Orange']
+        ]);
+
+        $this->assertEquals('Apple', $data->sortByDate('date')->first()['name']);
+        $this->assertEquals('Banana', $data->sortByDate('date')->last()['name']);
+    }
+
+    /** @test */
+    public function it_sorts_carbon_objects()
+    {
+        $data = new Collection([
+            Carbon::parse('2018-01-04'),
+            Carbon::parse('1995-07-15'),
+            Carbon::parse('2000-01-01')
+        ]);
+
+        $this->assertEquals('1995-07-15', $data->sortByDate()->first()->format('Y-m-d'));
+        $this->assertEquals('2018-01-04', $data->sortByDate()->last()->format('Y-m-d'));
+    }
+
+    /** @test */
+    public function it_sorts_using_callbacks()
+    {
+        $data = new Collection([
+            [
+                'name' => 'Banana',
+                'dates' => [
+                    'from' => '2018-01-04',
+                    'to' => '2019-01-01'
+                ]
+            ],
+            [
+                'name' => 'Apple',
+                'dates' => [
+                    'from' => '1995-07-15',
+                    'to' => '2019-06-12'
+                ]
+            ],
+            [
+                'name' => 'Orange',
+                'dates' => [
+                    'from' => '2000-01-01',
+                    'to' => '2020-04-31'
+                ]
+            ]
+        ]);
+
+        $this->assertEquals('Apple', $data->sortByDate(function($item) {
+            return $item['dates']['from'];
+        })->first()['name']);
+    }
+}


### PR DESCRIPTION
One thing I find myself doing all the time inside collections is sorting the data into chronological order. Collections' `sortBy` method paired with Carbon goes a long way, but 90% of the time this can be achieved the same way, so making it a macro keeps it simple.