### PR TITLE
Transpose count warning/exception php7.2

### DIFF
--- a/src/macros/transpose.php
+++ b/src/macros/transpose.php
@@ -14,7 +14,13 @@ Collection::macro('transpose', function (): Collection {
         return new static();
     }
 
-    $expectedLength = count($this->first());
+    $firstItem = $this->first();
+
+    if (! $firstItem instanceof Countable) {
+        return new static();
+    }
+
+    $expectedLength = count($firstItem);
 
     array_walk($this->items, function ($row) use ($expectedLength) {
         if (count($row) !== $expectedLength) {

--- a/src/macros/transpose.php
+++ b/src/macros/transpose.php
@@ -16,14 +16,10 @@ Collection::macro('transpose', function (): Collection {
 
     $firstItem = $this->first();
 
-    if (! $firstItem instanceof Countable) {
-        return new static();
-    }
-
-    $expectedLength = count($firstItem);
+    $expectedLength = is_array($firstItem) || $firstItem instanceof Countable ? count($firstItem) : 0;
 
     array_walk($this->items, function ($row) use ($expectedLength) {
-        if (count($row) !== $expectedLength) {
+        if ((is_array($row) || $row instanceof Countable) && count($row) !== $expectedLength) {
             throw new \LengthException("Element's length must be equal.");
         }
     });

--- a/tests/TransposeTest.php
+++ b/tests/TransposeTest.php
@@ -149,4 +149,16 @@ class TransposeTest extends TestCase
 
         $this->assertEquals($expected, $collection->transpose());
     }
+
+    /** @test */
+    public function it_can_handle_null_values()
+    {
+        $collection = new Collection([
+            null,
+        ]);
+
+        $expected = new Collection();
+
+        $this->assertEquals($expected, $collection->transpose());
+    }
 }

--- a/tests/TransposeTest.php
+++ b/tests/TransposeTest.php
@@ -161,4 +161,20 @@ class TransposeTest extends TestCase
 
         $this->assertEquals($expected, $collection->transpose());
     }
+
+    /** @test */
+    public function it_can_handle_collections_values()
+    {
+        $collection = new Collection([
+            new Collection([1, 2, 3]),
+        ]);
+
+        $expected = new Collection([
+            new Collection([1]),
+            new Collection([2]),
+            new Collection([3]),
+        ]);
+
+        $this->assertEquals($expected, $collection->transpose());
+    }
 }


### PR DESCRIPTION
If the very first item in the collection is not an array or something that is countable then this macro would throw a warning/exception. Instead now we just return an empty collection.
  