### PR TITLE
Update PaginateTest no to extend IntegrationTest, which caused ParallelMapTest failing

### DIFF
--- a/tests/Macros/PaginateTest.php
+++ b/tests/Macros/PaginateTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Spatie\CollectionMacros\Test;
+namespace Spatie\CollectionMacros\Test\Macros;
 
 use Illuminate\Support\Collection;
+use Spatie\CollectionMacros\Test\TestCase;
 
 class PaginateTest extends TestCase
 {

--- a/tests/Macros/PaginateTest.php
+++ b/tests/Macros/PaginateTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Spatie\CollectionMacros\Test\Macros;
+namespace Spatie\CollectionMacros\Test;
 
 use Illuminate\Support\Collection;
-use Spatie\CollectionMacros\Test\IntegrationTestCase;
 
-class PaginateTest extends IntegrationTestCase
+class PaginateTest extends TestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
Turned out the failing test was caused by previous test. 

Though my commit could fix the broken tests, I'm curious:
1) For what reason `PaginateTest` need to extend `IntegrationTestCase`?
2) I haven't figured out, but there might be issue on `IntegrationTestCase@tearDown`?

anyway, welcome to amend my commit.