### PR TITLE
Update tests namespace to align with the rest

### DIFF
--- a/tests/Macros/FirstOrFailTest.php
+++ b/tests/Macros/FirstOrFailTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Spatie\CollectionMacros\Test;
+namespace Spatie\CollectionMacros\Test\Macros;
 
 use Illuminate\Support\Collection;
+use Spatie\CollectionMacros\Test\TestCase;
 use Spatie\CollectionMacros\Exceptions\CollectionItemNotFound;
 
 class FirstOrFailTest extends TestCase

--- a/tests/Macros/ParallelMapTest.php
+++ b/tests/Macros/ParallelMapTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Spatie\CollectionMacros\Test;
+namespace Spatie\CollectionMacros\Test\Macros;
 
 use Illuminate\Support\Collection;
 use Amp\Parallel\Worker\DefaultPool;
+use Spatie\CollectionMacros\Test\TestCase;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 class ParallelMapTest extends TestCase

--- a/tests/Macros/PluckToArrayTest.php
+++ b/tests/Macros/PluckToArrayTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Spatie\CollectionMacros\Test;
+namespace Spatie\CollectionMacros\Test\Macros;
 
 use Illuminate\Support\Collection;
+use Spatie\CollectionMacros\Test\TestCase;
 
 class PluckToArrayTest extends TestCase
 {


### PR DESCRIPTION
A few tests' namespace are incorrect, update them to align with the rest of the tests