### PR TITLE
Add methods to get items by human named indexes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ The package will automatically register itself.
 
 - [`after`](#after)
 - [`at`](#at)
+    - [`second`](#second)
+    - [`third`](#third)
+    - [`fourth`](#fourth)
+    - [`fifth`](#fifth)
+    - [`sixth`](#sixth)
+    - [`seventh`](#seventh)
+    - [`eighth`](#eighth)
+    - [`ninth`](#ninth)
+    - [`tenth`](#tenth)
 - [`before`](#before)
 - [`chunkBy`](#chunkby)
 - [`collect`](#collect)
@@ -96,6 +105,87 @@ $data = new Collection([1, 2, 3]);
 $data->at(0); // 1
 $data->at(1); // 2
 $data->at(-1); // 3
+```
+
+### `second`
+Retrieve item at the second index.
+
+```php
+$data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+$data->second(); // 2
+```
+
+### `third`
+Retrieve item at the second index.
+
+```php
+$data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+$data->third(); // 3
+```
+
+### `fourth`
+Retrieve item at the second index.
+
+```php
+$data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+$data->fourth(); // 4
+```
+
+### `fifth`
+Retrieve item at the second index.
+
+```php
+$data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+$data->fifth(); // 5
+```
+
+### `sixth`
+Retrieve item at the second index.
+
+```php
+$data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+$data->sixth(); // 6
+```
+
+### `seventh`
+Retrieve item at the second index.
+
+```php
+$data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+$data->seventh(); // 7
+```
+
+### `eighth`
+Retrieve item at the second index.
+
+```php
+$data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+$data->eighth(); // 8
+```
+
+### `ninth`
+Retrieve item at the second index.
+
+```php
+$data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+$data->ninth(); // 9
+```
+
+### `tenth`
+Retrieve item at the second index.
+
+```php
+$data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+$data->tenth(); // 10
 ```
 
 ### `before`

--- a/src/macros/getHumanCount.php
+++ b/src/macros/getHumanCount.php
@@ -1,0 +1,102 @@
+<?php
+
+use Illuminate\Support\Collection;
+
+/*
+ * Get the second item from the collection.
+ *
+ * @param mixed $index
+ *
+ * @return mixed
+ */
+Collection::macro('second', function () {
+    return $this->get(1);
+});
+
+/*
+ * Get the third item from the collection.
+ *
+ * @param mixed $index
+ *
+ * @return mixed
+ */
+Collection::macro('third', function () {
+    return $this->get(2);
+});
+
+/*
+ * Get the fourth item from the collection.
+ *
+ * @param mixed $index
+ *
+ * @return mixed
+ */
+Collection::macro('fourth', function () {
+    return $this->get(3);
+});
+
+/*
+ * Get the fifth item from the collection.
+ *
+ * @param mixed $index
+ *
+ * @return mixed
+ */
+Collection::macro('fifth', function () {
+    return $this->get(4);
+});
+
+/*
+ * Get the sixth item from the collection.
+ *
+ * @param mixed $index
+ *
+ * @return mixed
+ */
+Collection::macro('sixth', function () {
+    return $this->get(5);
+});
+
+/*
+ * Get the seventh item from the collection.
+ *
+ * @param mixed $index
+ *
+ * @return mixed
+ */
+Collection::macro('seventh', function () {
+    return $this->get(6);
+});
+
+/*
+ * Get the eighth item from the collection.
+ *
+ * @param mixed $index
+ *
+ * @return mixed
+ */
+Collection::macro('eighth', function () {
+    return $this->get(7);
+});
+
+/*
+ * Get the ninth item from the collection.
+ *
+ * @param mixed $index
+ *
+ * @return mixed
+ */
+Collection::macro('ninth', function () {
+    return $this->get(8);
+});
+
+/*
+ * Get the tenth item from the collection.
+ *
+ * @param mixed $index
+ *
+ * @return mixed
+ */
+Collection::macro('tenth', function () {
+    return $this->get(9);
+});

--- a/tests/Macros/GetHumanCountTest.php
+++ b/tests/Macros/GetHumanCountTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test\Macros;
+
+use Illuminate\Support\Collection;
+use Spatie\CollectionMacros\Test\TestCase;
+
+class GetHumanCountTest extends TestCase
+{
+    /** @test */
+    public function it_gets_the_first_item_of_the_collection()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        $this->assertEquals(1, $data->first());
+    }
+
+    /** @test */
+    public function it_gets_the_second_item_of_the_collection()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        $this->assertEquals(2, $data->second());
+    }
+
+    /** @test */
+    public function it_gets_the_third_item_of_the_collection()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        $this->assertEquals(3, $data->third());
+    }
+
+    /** @test */
+    public function it_gets_the_fourth_item_of_the_collection()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        $this->assertEquals(4, $data->fourth());
+    }
+
+    /** @test */
+    public function it_gets_the_fifth_item_of_the_collection()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        $this->assertEquals(5, $data->fifth());
+    }
+
+    /** @test */
+    public function it_gets_the_sixth_item_of_the_collection()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        $this->assertEquals(6, $data->sixth());
+    }
+
+    /** @test */
+    public function it_gets_the_seventh_item_of_the_collection()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        $this->assertEquals(7, $data->seventh());
+    }
+
+    /** @test */
+    public function it_gets_the_eighth_item_of_the_collection()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        $this->assertEquals(8, $data->eighth());
+    }
+
+    /** @test */
+    public function it_gets_the_ninth_item_of_the_collection()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        $this->assertEquals(9, $data->ninth());
+    }
+
+    /** @test */
+    public function it_gets_the_tenth_item_of_the_collection()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        $this->assertEquals(10, $data->tenth());
+    }
+
+    /** @test */
+    public function it_returns_null_if_index_is_undefined()
+    {
+        $data = new Collection();
+
+        $this->assertEquals(null, $data->first());
+        $this->assertEquals(null, $data->second());
+        $this->assertEquals(null, $data->third());
+        $this->assertEquals(null, $data->fourth());
+        $this->assertEquals(null, $data->fifth());
+        $this->assertEquals(null, $data->sixth());
+        $this->assertEquals(null, $data->seventh());
+        $this->assertEquals(null, $data->eighth());
+        $this->assertEquals(null, $data->ninth());
+        $this->assertEquals(null, $data->tenth());
+    }
+}


### PR DESCRIPTION
### About
It was proposed in #132 that we should in the spirit of Rails (https://github.com/rails/rails/commit/22af62cf486721ee2e45bb720c42ac2f4121faf4), have humanly-plain methods to access *indexes* zero one through nine via *methods* one through ten.

Although [current rails](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/array/access.rb#L47) now ranges from *one* through *five*, I am rooting for keeping this PR at ten because:
- Having little historical pointers is fun [hint](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/array/access.rb#L75)
- I've pulled through and written all the words in all the files 🎉 

### Considerations
I made a few decisions that are differet from the rest of the projects:
1. Multiple macros in one file
2. Testing multiple macros in one test case
3. Made new methods sub-items of `at`

I chose to do this because these are very similar and for me it seemed more organized to group these macros together.
As to the nesting under `at`-macro I thought:
- They were categorically similar
- Having each method sorted alphabetically will make it hard to grasp how far the macros count