### PR TITLE
add head macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The package will automatically register itself.
 - [`fromPairs`](#frompairs)
 - [`glob`](#glob)
 - [`groupByModel`](#groupbymodel)
+- [`head`](#head)
 - [`ifAny`](#ifany)
 - [`ifEmpty`](#ifempty)
 - [`none`](#none)
@@ -329,6 +330,20 @@ $posts->groupByModel('category');
 ```
 
 Full signature: `groupByModel($callback, $preserveKeys, $modelKey, $itemsKey)`
+
+### `head`
+
+Retrieves first item from the collection.
+
+```php
+$collection = collect([1,2,3]);
+
+$collection->head(); // return 1
+
+$collection = collect([]);
+
+$collection->head(); // return null
+```
 
 ### `ifAny`
 

--- a/src/macros/head.php
+++ b/src/macros/head.php
@@ -1,0 +1,12 @@
+<?php
+
+use Illuminate\Support\Collection;
+
+/*
+ * Get the first item from the collection.
+ *
+ * @return mixed
+ */
+Collection::macro('head', function() {
+    return $this->first();
+});

--- a/tests/Macros/HeadTest.php
+++ b/tests/Macros/HeadTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test\Macros;
+
+use Illuminate\Support\Collection;
+use Spatie\CollectionMacros\Test\TestCase;
+
+class HeadTest extends TestCase
+{
+    /** @test */
+    public function it_provides_head_macro()
+    {
+        $this->assertTrue(Collection::hasMacro('head'));
+    }
+
+    /** @test */
+    public function it_gets_the_first_item_of_the_collection()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        $this->assertEquals(1, $data->head());
+    }
+
+    /** @test */
+    public function it_returns_null_if_the_collection_is_empty()
+    {
+        $data = new Collection();
+
+        $this->assertNull($data->head());
+    }
+}


### PR DESCRIPTION
There is already a `tail` macro, so, for consistency sake, it would be nice to have a `head` macro as well (just like `lodash.com` has).


