### PR TITLE
Use registry over file scan + string manipulation

### DIFF
--- a/src/CollectionMacroServiceProvider.php
+++ b/src/CollectionMacroServiceProvider.php
@@ -4,25 +4,58 @@ namespace Spatie\CollectionMacros;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Str;
 
 class CollectionMacroServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        Collection::make(glob(__DIR__.'/Macros/*.php'))
-            ->mapWithKeys(fn ($path) => [$path => pathinfo($path, PATHINFO_FILENAME)])
-            ->reject(fn ($macro) => Collection::hasMacro($macro))
-            ->each(function ($macro, $path) {
-                $class = "Spatie\\CollectionMacros\\Macros\\{$macro}";
+        Collection::make($this->macros())
+            ->reject(fn($class, $macro) => Collection::hasMacro($macro))
+            ->each(fn($class, $macro) => Collection::macro($macro, app($class)()));
+    }
 
-                $macro = Str::camel($macro);
-
-                if ($macro === 'tryCatch') {
-                    $macro = 'try';
-                }
-
-                Collection::macro($macro, app($class)());
-            });
+    private function macros(): array
+    {
+        return [
+            'after' => \Spatie\CollectionMacros\Macros\After::class,
+            'at' => \Spatie\CollectionMacros\Macros\At::class,
+            'before' => \Spatie\CollectionMacros\Macros\Before::class,
+            'chunkBy' => \Spatie\CollectionMacros\Macros\ChunkBy::class,
+            'collectBy' => \Spatie\CollectionMacros\Macros\CollectBy::class,
+            'eachCons' => \Spatie\CollectionMacros\Macros\EachCons::class,
+            'eighth' => \Spatie\CollectionMacros\Macros\Eighth::class,
+            'extract' => \Spatie\CollectionMacros\Macros\Extract::class,
+            'fifth' => \Spatie\CollectionMacros\Macros\Fifth::class,
+            'filterMap' => \Spatie\CollectionMacros\Macros\FilterMap::class,
+            'firstOrFail' => \Spatie\CollectionMacros\Macros\FirstOrFail::class,
+            'fourth' => \Spatie\CollectionMacros\Macros\Fourth::class,
+            'fromPairs' => \Spatie\CollectionMacros\Macros\FromPairs::class,
+            'glob' => \Spatie\CollectionMacros\Macros\Glob::class,
+            'groupByModel' => \Spatie\CollectionMacros\Macros\GroupByModel::class,
+            'head' => \Spatie\CollectionMacros\Macros\Head::class,
+            'ifAny' => \Spatie\CollectionMacros\Macros\IfAny::class,
+            'ifEmpty' => \Spatie\CollectionMacros\Macros\IfEmpty::class,
+            'ninth' => \Spatie\CollectionMacros\Macros\Ninth::class,
+            'none' => \Spatie\CollectionMacros\Macros\None::class,
+            'paginate' => \Spatie\CollectionMacros\Macros\Paginate::class,
+            'parallelMap' => \Spatie\CollectionMacros\Macros\ParallelMap::class,
+            'pluckToArray' => \Spatie\CollectionMacros\Macros\PluckToArray::class,
+            'prioritize' => \Spatie\CollectionMacros\Macros\Prioritize::class,
+            'rotate' => \Spatie\CollectionMacros\Macros\Rotate::class,
+            'second' => \Spatie\CollectionMacros\Macros\Second::class,
+            'sectionBy' => \Spatie\CollectionMacros\Macros\SectionBy::class,
+            'seventh' => \Spatie\CollectionMacros\Macros\Seventh::class,
+            'simplePaginate' => \Spatie\CollectionMacros\Macros\SimplePaginate::class,
+            'sixth' => \Spatie\CollectionMacros\Macros\Sixth::class,
+            'sliceBefore' => \Spatie\CollectionMacros\Macros\SliceBefore::class,
+            'tail' => \Spatie\CollectionMacros\Macros\Tail::class,
+            'tenth' => \Spatie\CollectionMacros\Macros\Tenth::class,
+            'third' => \Spatie\CollectionMacros\Macros\Third::class,
+            'toPairs' => \Spatie\CollectionMacros\Macros\ToPairs::class,
+            'transpose' => \Spatie\CollectionMacros\Macros\Transpose::class,
+            'try' => \Spatie\CollectionMacros\Macros\TryCatch::class,
+            'validate' => \Spatie\CollectionMacros\Macros\Validate::class,
+            'withSize' => \Spatie\CollectionMacros\Macros\WithSize::class,
+        ];
     }
 }

--- a/tests/Macros/TryCatchTest.php
+++ b/tests/Macros/TryCatchTest.php
@@ -9,6 +9,7 @@ use UnexpectedValueException;
 
 class TryCatchTest extends TestCase
 {
+    /** @test */
     public function it_will_not_execute_the_callable_in_catch_when_no_exception_was_thrown()
     {
         $collection = collect(['a', 'b', 'c', 1, 2, 3])
@@ -23,6 +24,7 @@ class TryCatchTest extends TestCase
         $this->assertEquals(['A', 'B', 'C', 1, 2, 3], $collection->toArray());
     }
 
+    /** @test */
     public function the_catch_method_will_handle_a_thrown_exception()
     {
         $collection = collect(['a', 'b', 'c', 1, 2, 3])
@@ -37,6 +39,7 @@ class TryCatchTest extends TestCase
         $this->assertEquals(['a', 'b', 'c', 1, 2, 3], $collection->toArray());
     }
 
+    /** @test */
     public function the_catch_method_will_catch_exception_of_the_right_type()
     {
         $collection = collect(['a', 'b', 'c', 1, 2, 3])
@@ -53,6 +56,7 @@ class TryCatchTest extends TestCase
         $this->assertEquals(['a', 'b', 'c', 1, 2, 3], $collection->toArray());
     }
 
+    /** @test */
     public function the_catch_method_will_not_handle_unrelated_exceptions()
     {
         $this->expectException(Exception::class);
@@ -70,6 +74,7 @@ class TryCatchTest extends TestCase
         $this->assertEquals(['a', 'b', 'c', 1, 2, 3], $collection->toArray());
     }
 
+    /** @test */
     public function when_no_typehint_is_used_the_catch_method_will_catch_all_exceptions()
     {
         $collection = collect(['a', 'b', 'c', 1, 2, 3])
@@ -84,6 +89,7 @@ class TryCatchTest extends TestCase
         $this->assertEquals(['a', 'b', 'c', 1, 2, 3], $collection->toArray());
     }
 
+    /** @test */
     public function when_no_parameters_are_given_to_catch_it_will_catch_all_exceptions()
     {
         $caught = false;
@@ -100,6 +106,7 @@ class TryCatchTest extends TestCase
         $this->assertTrue($caught);
     }
 
+    /** @test */
     public function the_catch_handle_can_receive_the_original_collection()
     {
         $collection = collect(['a', 'b', 'c', 1, 2, 3])
@@ -118,6 +125,7 @@ class TryCatchTest extends TestCase
         $this->assertEquals(['a', 'b', 'c', 1, 2, 3], $collection->toArray());
     }
 
+    /** @test */
     public function the_catch_handler_can_return_a_collection()
     {
         $collection = collect(['a', 'b', 'c', 1, 2, 3])
@@ -134,6 +142,7 @@ class TryCatchTest extends TestCase
         $this->assertEquals(['d', 'e', 'f'], $collection->toArray());
     }
 
+    /** @test */
     public function any_method_after_catch_will_receive_the_original_collection_when_an_exception_was_caught()
     {
         $collection = collect(['a', 'b', 'c', 1, 2, 3])


### PR DESCRIPTION
This contains the refactors we discussed in [our pairing session](https://www.youtube.com/watch?v=i8PyAtqvgKc&list=PLmwAMIdrAmK5rH3SWvokHV8xI_0mauxDL&index=36) to remove the file system scans on register.

In doing so, this _registry_ of macro/FQCN removed the need for the logic to build the class and macro names, as well as the special condition added for `try`.

Also adds the missing tests annotations for the `TryCatchTest` to remove the _risky test_.