### PR TITLE
Add accumulate macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The package will automatically register itself.
 
 ## Macros
 
+- [`accumulate`](#accumulate)
 - [`after`](#after)
 - [`at`](#at)
     - [`second`](#second)
@@ -72,6 +73,16 @@ The package will automatically register itself.
 - [`transpose`](#transpose)
 - [`validate`](#validate)
 - [`withSize`](#withsize)
+
+### `accumulate`
+
+Accumulate the items in the collection.
+
+```php
+$collection = collect([1,2,3]);
+
+$data->accumulate(); // Collection([1,3,6])
+```
 
 ### `after`
 

--- a/src/CollectionMacroServiceProvider.php
+++ b/src/CollectionMacroServiceProvider.php
@@ -17,6 +17,7 @@ class CollectionMacroServiceProvider extends ServiceProvider
     private function macros(): array
     {
         return [
+            'accumulate' => \Spatie\CollectionMacros\Macros\Accumulate::class,
             'after' => \Spatie\CollectionMacros\Macros\After::class,
             'at' => \Spatie\CollectionMacros\Macros\At::class,
             'before' => \Spatie\CollectionMacros\Macros\Before::class,

--- a/src/Macros/Accumulate.php
+++ b/src/Macros/Accumulate.php
@@ -16,7 +16,7 @@ class Accumulate
 {
     public function __invoke()
     {
-        return function ($callback = null, $initial = 0) {
+        return function ($callback = null, $initial = null) {
             if (is_null($callback)) {
                 $callback = function ($value) {
                     return $value;

--- a/src/Macros/Accumulate.php
+++ b/src/Macros/Accumulate.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Spatie\CollectionMacros\Macros;
+
+/**
+ * Accumulate values through the collection.
+ *
+ * @param callable|string|null $callback
+ * @param mixed $initial
+ *
+ * @mixin \Illuminate\Support\Collection
+ *
+ * @return mixed
+ */
+class Accumulate
+{
+    public function __invoke()
+    {
+        return function ($callback = null, $initial = 0) {
+            if (is_null($callback)) {
+                $callback = function ($value) {
+                    return $value;
+                };
+            } else {
+                $callback = $this->valueRetriever($callback);
+            }
+
+            $tally = $initial;
+
+            return $this->map(function ($item) use (&$tally, $callback) {;
+                return $tally += $callback($item);
+            });
+        };
+    }
+}

--- a/tests/Macros/AccumulateTest.php
+++ b/tests/Macros/AccumulateTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test\Macros;
+
+use Illuminate\Support\Collection;
+use Spatie\CollectionMacros\Test\TestCase;
+
+class AccumulateTest extends TestCase
+{
+    /** @test */
+    public function it_provides_an_accumulate_macro()
+    {
+        $this->assertTrue(Collection::hasMacro('accumulate'));
+    }
+
+    /** @test */
+    public function it_can_accumulate_values()
+    {
+        $data = new Collection([1, 2, 3, 4, 5]);
+
+        $this->assertEquals([1, 3, 6, 10, 15], $data->accumulate()->toArray());
+    }
+
+    /** @test */
+    public function it_can_accumulate_with_callback()
+    {
+        $data = new Collection([1, 2, 3, 4, 5]);
+
+        $result = $data->accumulate(function ($value) {
+            return $value * 2;
+        });
+
+        $this->assertEquals([2, 6, 12, 20, 30], $result->toArray());
+    }
+
+    /** @test */
+    public function it_can_accumulate_with_key()
+    {
+        $data = new Collection([
+            ['sales' => 10],
+            ['sales' => 20],
+            ['sales' => 30],
+        ]);
+
+        $result = $data->accumulate('sales');
+
+        $this->assertEquals([10, 30, 60], $result->toArray());
+    }
+
+    /** @test */
+    public function it_can_accumulate_values_with_initial()
+    {
+        $data = new Collection([1, 2, 3, 4, 5]);
+
+        $result = $data->accumulate(null, 1);
+
+        $this->assertEquals([2, 4, 7, 11, 16], $result->toArray());
+    }
+}


### PR DESCRIPTION
This adds `accumulate` which maps over an array tallying up the values.

It uses the same interface as the existing `sum` method - i.e. you can call it without an argument, use the key name of a value, or a callback to do whatever magic you'd like. In addition you can provide the initial value much like `reduce`.