### PR TITLE
Enable Laravel 8

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,6 +14,9 @@ jobs:
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   testbench: 6.*
+                        laravel: 8.*
+                    -   testbench: 5.*
+                        laravel: 7.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
                 laravel: [7.*, 8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
-                    -   testbench: 5.*
+                    -   testbench: 6.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,11 +10,10 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 php: [7.4]
-                laravel: [7.*]
+                laravel: [7.*, 8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
-                    -   laravel: 7.*
-                        testbench: 5.*
+                    -   testbench: 5.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": "^7.4",
-        "illuminate/support": "^7.0"
+        "illuminate/support": "^7.0 || ^8.0"
     },
     "require-dev": {
         "amphp/parallel": "^0.2.5",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Spatie Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Spatie Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
This adds Laravel 8 to the versions in composer.json (via `illuminate/support`), and also enables Laravel 8 testing in the test matrix.

I've not looked at test coverage, but the tests all run fine with both Laravel 7 and 8.