### PR TITLE
Fix PHPUnit fixtures usage

### DIFF
--- a/tests/Macros/ExtractTest.php
+++ b/tests/Macros/ExtractTest.php
@@ -10,7 +10,7 @@ class ExtractTest extends TestCase
     /** @var \Illuminate\Support\Collection */
     private $user = null;
 
-    public function setup(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Macros/IfAnyTest.php
+++ b/tests/Macros/IfAnyTest.php
@@ -11,14 +11,14 @@ class IfAnyTest extends TestCase
     /** @var \Mockery\MockInterface spy */
     private $spy;
 
-    public function setup(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->spy = Mockery::spy();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         if ($container = Mockery::getContainer()) {
             $this->addToAssertionCount($container->mockery_getExpectationCount());

--- a/tests/Macros/IfEmptyTest.php
+++ b/tests/Macros/IfEmptyTest.php
@@ -11,14 +11,14 @@ class IfEmptyTest extends TestCase
     /** @var \Mockery\MockInterface spy */
     private $spy;
 
-    public function setup(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->spy = Mockery::spy();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         if ($container = Mockery::getContainer()) {
             $this->addToAssertionCount($container->mockery_getExpectationCount());

--- a/tests/Macros/PaginateTest.php
+++ b/tests/Macros/PaginateTest.php
@@ -7,7 +7,7 @@ use Spatie\CollectionMacros\Test\TestCase;
 
 class PaginateTest extends TestCase
 {
-    public function setup(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Macros/ParallelMapTest.php
+++ b/tests/Macros/ParallelMapTest.php
@@ -12,7 +12,7 @@ class ParallelMapTest extends TestCase
     /** Symfony\Component\Stopwatch\Stopwatch */
     protected $stopWatch;
 
-    public function setup(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,7 +8,7 @@ use Spatie\CollectionMacros\CollectionMacroServiceProvider;
 
 abstract class TestCase extends BaseTestCase
 {
-    public function setup(): void
+    protected function setUp(): void
     {
         $this->createDummyprovider()->register();
     }


### PR DESCRIPTION
# Changed log

- According to the official [PHPUnit doc](https://phpunit.readthedocs.io/en/9.5/fixtures.html#more-setup-than-teardown), it should be the `protected function setUp(): void` and `protected function tearDown(): void`.