### PR TITLE
Improve assertions about InstanceOf and Array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 .php_cs.cache
+.phpunit.result.cache

--- a/tests/Macros/CollectByTest.php
+++ b/tests/Macros/CollectByTest.php
@@ -23,7 +23,7 @@ class CollectByTest extends TestCase
 
         $ingredients = $collection->collectBy('ingredients');
 
-        $this->assertTrue(is_a($ingredients, Collection::class));
+        $this->assertInstanceOf(Collection::class, $ingredients);
 
         $this->assertEquals([
             'cheese',

--- a/tests/Macros/PluckToArrayTest.php
+++ b/tests/Macros/PluckToArrayTest.php
@@ -20,7 +20,7 @@ class PluckToArrayTest extends TestCase
 
         $this->assertEquals($expected, $result);
 
-        $this->assertTrue(is_array($result));
+        $this->assertIsArray($result);
     }
 
     /** @test */


### PR DESCRIPTION
# Changed log

- Let the `.phpunit.result.cache` be on the `.gitignore` file and be not under Git version control.
- Using the `assertIsArray` to assert type is `array`.
- Using the `assertInstanceOf` to assert the expected instance is same as `Collection::class`.