### PR TITLE
add getNth macro

### DIFF
--- a/src/CollectionMacroServiceProvider.php
+++ b/src/CollectionMacroServiceProvider.php
@@ -30,6 +30,7 @@ class CollectionMacroServiceProvider extends ServiceProvider
             'firstOrFail' => \Spatie\CollectionMacros\Macros\FirstOrFail::class,
             'fourth' => \Spatie\CollectionMacros\Macros\Fourth::class,
             'fromPairs' => \Spatie\CollectionMacros\Macros\FromPairs::class,
+            'getNth' => \Spatie\CollectionMacros\Macros\GetNth::class,
             'glob' => \Spatie\CollectionMacros\Macros\Glob::class,
             'groupByModel' => \Spatie\CollectionMacros\Macros\GroupByModel::class,
             'head' => \Spatie\CollectionMacros\Macros\Head::class,

--- a/src/Macros/GetNth.php
+++ b/src/Macros/GetNth.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\CollectionMacros\Macros;
+
+/***
+ * Get the previous item from the collection.
+ *
+ * @param int $nth
+ * @param mixed $fallback
+ *
+ * @mixin \Illuminate\Support\Collection
+ *
+ * @return mixed
+ */
+class GetNth
+{
+    public function __invoke()
+    {
+        return function (int $nth) {
+            return $this->skip($nth - 1)->first();
+        };
+    }
+}

--- a/tests/Macros/GetHumanCountTest.php
+++ b/tests/Macros/GetHumanCountTest.php
@@ -87,6 +87,15 @@ class GetHumanCountTest extends TestCase
         $this->assertEquals(10, $data->tenth());
     }
 
+
+    /** @test */
+    public function it_gets_the_nth_item_of_the_collection()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+
+        $this->assertEquals(11, $data->getNth(11));
+    }
+
     /** @test */
     public function it_returns_null_if_index_is_undefined()
     {
@@ -102,5 +111,6 @@ class GetHumanCountTest extends TestCase
         $this->assertNull($data->eighth());
         $this->assertNull($data->ninth());
         $this->assertNull($data->tenth());
+        $this->assertNull($data->getNth(11));
     }
 }


### PR DESCRIPTION
This adds a `getNth($nth)` macro to get any nth item from the collection.

For example:
```php
$data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);

$data->getNth(11); // 11
```

I would even suggest maybe this macro can replace the `second`, `third`, `fourth` ... `tenth` macros