### PR TITLE
Adds `firstOrPush` as a collection macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The package will automatically register itself.
 - [`extract`](#extract)
 - [`filterMap`](#filtermap)
 - [`firstOrFail`](#firstorfail)
+- [`firstOrPush`](#firstorpush)
 - [`fromPairs`](#frompairs)
 - [`glob`](#glob)
 - [`groupByModel`](#groupbymodel)
@@ -310,6 +311,26 @@ $collection = collect([1, 2, 3, 4, 5, 6])->firstOrFail();
 $collection->toArray(); // returns [1]
 
 collect([])->firstOrFail(); // throws Spatie\CollectionMacros\Exceptions\CollectionItemNotFound
+```
+
+### `firstOrPush`
+
+Retrieve the first item using the callable given as the first parameter. If no value exists, push the value of the second
+parameter into the collection. You can pass a callable as the second parameter.
+
+```php
+$collection = collect([1, 2, 3])->firstOrPush(fn($item) => $item === 4, 4);
+
+$collection->toArray(); // returns [1, 2, 3, 4]
+```
+
+Occasionally, you'll want to specify the target collection to be pushed to. You may pass this as a third parameter.
+
+```php
+$collection = collect([1, 2, 3]);
+$collection->filter()->firstOrPush(fn($item) => $item === 4, 4, $collection);
+
+$collection->toArray(); // returns [1, 2, 3, 4]
 ```
 
 ### `fromPairs`

--- a/src/CollectionMacroServiceProvider.php
+++ b/src/CollectionMacroServiceProvider.php
@@ -28,6 +28,7 @@ class CollectionMacroServiceProvider extends ServiceProvider
             'fifth' => \Spatie\CollectionMacros\Macros\Fifth::class,
             'filterMap' => \Spatie\CollectionMacros\Macros\FilterMap::class,
             'firstOrFail' => \Spatie\CollectionMacros\Macros\FirstOrFail::class,
+            'firstOrPush' => \Spatie\CollectionMacros\Macros\FirstOrPush::class,
             'fourth' => \Spatie\CollectionMacros\Macros\Fourth::class,
             'fromPairs' => \Spatie\CollectionMacros\Macros\FromPairs::class,
             'getNth' => \Spatie\CollectionMacros\Macros\GetNth::class,

--- a/src/Macros/FirstOrPush.php
+++ b/src/Macros/FirstOrPush.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\CollectionMacros\Macros;
+
+use Illuminate\Support\Enumerable;
+
+/**
+ * Retrieve the first item that passes the given callback, or push
+ * the resolved callable into the collection and return it if
+ * no matching value is found. You may specify the collection
+ * instance to push into as a third parameter.
+ *
+ * @param callable $callable
+ * @param callable|mixed $value
+ * @param Enumerable|null $instance
+ *
+ * @mixin \Illuminate\Support\Collection
+ *
+ * @return mixed
+ */
+class FirstOrPush
+{
+    public function __invoke()
+    {
+        return function ($callback, $value, $instance = null) {
+            return $this->first($callback) ?? tap(
+                value($value),
+                fn ($resolved) => ($instance ?? $this)->push($resolved)
+            );
+        };
+    }
+}

--- a/tests/Macros/FirstOrPushTest.php
+++ b/tests/Macros/FirstOrPushTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test\Macros;
+
+use Illuminate\Support\Collection;
+use Spatie\CollectionMacros\Test\TestCase;
+
+class FirstOrPushTest extends TestCase
+{
+    /** @test */
+    public function it_can_retrieve_a_value_if_one_exists()
+    {
+        $data = new Collection([1, 2, 3]);
+
+        $this->assertEquals(1, $data->firstOrPush(fn($item) => $item === 1, 2));
+    }
+
+    /** @test */
+    public function if_a_value_doesnt_exist_the_second_argument_is_pushed_in_to_the_collection_and_returned()
+    {
+        $data = new Collection([1, 2]);
+
+        $this->assertEquals(3, $data->firstOrPush(fn($item) => $item === 3, 3));
+        $this->assertEquals(3, $data->firstOrPush(fn($item) => $item === 3, 4));
+    }
+
+    /** @test */
+    public function the_value_parameter_can_be_a_callable()
+    {
+        $this->assertEquals(1, (new Collection())->firstOrPush(fn($item) => false, fn() => 1));
+    }
+
+    /** @test */
+    public function a_collection_object_can_be_specified_as_the_push_target()
+    {
+        $data = new Collection([1, 2, 3]);
+        $data->filter(fn($item) => false)->firstOrPush(fn($item) => false, 4, $data);
+
+        $this->assertEquals(new Collection([1, 2, 3, 4]), $data);
+    }
+}


### PR DESCRIPTION
Howdy guys!

Hope you're well and having a great Thursday.

This PR adds a new macro, `firstOrPush`. This method will attempt to retrieve a value from the collection using the provided truth test. If no value is found, it will push the result of the second parameter into the collection:

```php
$collection = collect([1, 2, 3])->firstOrPush(fn($item) => $item === 4, fn() => 4);

$collection->toArray(); // returns [1, 2, 3, 4]
```

You can also provide a collection instance to push into as a third parameter. This is useful when you've chained other methods onto the collection, and want to target the initial collection instance:

```php
$collection = collect([1, 2, 3]);
$collection->filter()->firstOrPush(fn($item) => $item === 4, 4, $collection);

$collection->toArray(); // returns [1, 2, 3, 4]
```

This method is really useful when dealing with cached class properties, where you want to store a value retrieved from an API or computationally expensive function in a collection to be used multiple times.

Thanks for all the hard work.

Kind Regards,
Luke