### PR TITLE
Add pluckMany macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The package will automatically register itself.
 - [`none`](#none)
 - [`paginate`](#paginate)
 - [`parallelMap`](#parallelmap)
+- [`pluckMany`](#pluckmany)
 - [`pluckToArray`](#plucktoarray)
 - [`prioritize`](#prioritize)
 - [`rotate`](#rotate)
@@ -479,6 +480,25 @@ $pageSources = collect($urls)->parallelMap(function($url) {
 ```
 
 This helps to reduce the memory overhead, as the default worker pool limit is `32` (as defined in `amphp/parallel`). Using fewer worker threads can significantly reduce memory and processing overhead, in many cases. Benchmark and customise the worker thread limit to suit your particular use-case.
+
+### `pluckMany`
+
+Returns a collection with only the specified keys.
+
+```php
+$collection = collect([
+    ['a' => 1, 'b' => 10, 'c' => 100],
+    ['a' => 2, 'b' => 20, 'c' => 200],
+]);
+
+$collection->pluckMany(['a', 'b']);
+
+// returns
+// collect([
+//     ['a' => 1, 'b' => 10],
+//     ['a' => 2, 'b' => 20],
+// ]);
+```
 
 ### `pluckToArray`
 

--- a/src/CollectionMacroServiceProvider.php
+++ b/src/CollectionMacroServiceProvider.php
@@ -41,6 +41,7 @@ class CollectionMacroServiceProvider extends ServiceProvider
             'none' => \Spatie\CollectionMacros\Macros\None::class,
             'paginate' => \Spatie\CollectionMacros\Macros\Paginate::class,
             'parallelMap' => \Spatie\CollectionMacros\Macros\ParallelMap::class,
+            'pluckMany' => \Spatie\CollectionMacros\Macros\PluckMany::class,
             'pluckToArray' => \Spatie\CollectionMacros\Macros\PluckToArray::class,
             'prioritize' => \Spatie\CollectionMacros\Macros\Prioritize::class,
             'rotate' => \Spatie\CollectionMacros\Macros\Rotate::class,

--- a/src/Macros/PluckMany.php
+++ b/src/Macros/PluckMany.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Spatie\CollectionMacros\Macros;
+
+use ArrayAccess;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+
+/**
+ * Get the value of several keys.
+ *
+ * @param  array  $keys
+ *
+ * @mixin \Illuminate\Support\Collection
+ *
+ * @return array
+ */
+class PluckMany
+{
+    public function __invoke()
+    {
+        return function ($keys): Collection
+        {
+            return $this->map(function ($item) use ($keys) {
+                if ($item instanceof Collection) {
+                    return $item->only($keys);
+                }
+    
+                if (is_array($item)) {
+                    return Arr::only($item, $keys);
+                }
+    
+                if ($item instanceof ArrayAccess) {
+                    return collect($keys)->mapWithKeys(function ($key) use ($item) {
+                        return [$key => $item[$key]];
+                    })->toArray();
+                }
+    
+                return (object) Arr::only(get_object_vars($item), $keys);
+            });
+        };
+    }
+}

--- a/src/Macros/PluckMany.php
+++ b/src/Macros/PluckMany.php
@@ -7,13 +7,13 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 /**
- * Get the value of several keys.
+ * Get a Collection with only the specified keys.
  *
  * @param  array  $keys
  *
  * @mixin \Illuminate\Support\Collection
  *
- * @return array
+ * @return Collection
  */
 class PluckMany
 {

--- a/tests/Macros/PluckManyTest.php
+++ b/tests/Macros/PluckManyTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test\Macros;
+
+use ArrayAccess;
+use Illuminate\Support\Collection;
+use Spatie\CollectionMacros\Test\TestCase;
+
+class PluckManyTest extends TestCase
+{
+    /** @test */
+    public function it_provides_a_pluckMany_macro()
+    {
+        $this->assertTrue(Collection::hasMacro('pluckMany'));
+    }
+
+    /** @test */
+    public function it_can_pluck_from_a_collection_of_collections()
+    {
+        $data = Collection::make([
+            collect(['id' => 1, 'name' => 'matt', 'hobby' => 'coding']),
+            collect(['id' => 2, 'name' => 'tomo', 'hobby' => 'cooking']),
+        ]);
+
+        $this->assertEquals($data->map->only(['name', 'hobby']), $data->pluckMany(['name', 'hobby']));
+    }
+
+    /** @test */
+    public function it_can_pluck_from_array_and_object_items()
+    {
+        $data = Collection::make([
+            (object) ['id' => 1, 'name' => 'matt', 'hobby' => 'coding'],
+            ['id' => 2, 'name' => 'tomo', 'hobby' => 'cooking'],
+        ]);
+
+        $this->assertEquals([
+            (object) ['name' => 'matt', 'hobby' => 'coding'],
+            ['name' => 'tomo', 'hobby' => 'cooking'],
+        ],
+            $data->pluckMany(['name', 'hobby'])->all()
+        );
+    }
+
+    /** @test */
+    public function it_can_pluck_from_objects_that_implement_array_access_interface()
+    {
+        $data = Collection::make([
+            new TestArrayAccessImplementation(['id' => 1, 'name' => 'marco', 'hobby' => 'drinking']),
+            new TestArrayAccessImplementation(['id' => 2, 'name' => 'belle', 'hobby' => 'cross-stitch']),
+        ]);
+
+        $this->assertEquals([
+            ['name' => 'marco', 'hobby' => 'drinking'],
+            ['name' => 'belle', 'hobby' => 'cross-stitch'],
+        ],
+            $data->pluckMany(['name', 'hobby'])->all()
+        );
+    }
+}
+
+class TestArrayAccessImplementation implements ArrayAccess
+{
+    private $arr;
+
+    public function __construct($arr)
+    {
+        $this->arr = $arr;
+    }
+
+    public function offsetExists($offset)
+    {
+        return isset($this->arr[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->arr[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $this->arr[$offset] = $value;
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->arr[$offset]);
+    }
+}


### PR DESCRIPTION
Hi, I was about to create a package for this, but I found yours and thought it would be better here.

This is a macro to pluck more than one key from a collection at a time.

## Example usage
```
$collection = collect([
    ['a' => 1, 'b' => 10, 'c' => 100],
    ['a' => 2, 'b' => 20, 'c' => 200],
]);

$collection->pluckMany(['a', 'b']);

// returns
// collect([
//     ['a' => 1, 'b' => 10],
//     ['a' => 2, 'b' => 20],
// ]);
```

This is the same behaviour as a line like `$collection->map->only(['name', 'email'])`, but the macro is more convenient and works on items of various types (e.g. not just items of type Collection, but also arrays, objects, objects that implement the ArrayAccess interface, and any combination of these).

Here is its behaviour on items of various types:
```
$collection = collect([
    ['id' => 1, 'name' => 'matt', 'hobby' => 'coding'],
    (object) ['id' => 2, 'name' => 'tomo', 'hobby' => 'cooking'],
    new ImplementsArrayAccess(['id' => 3, 'name' => 'marco', 'hobby' => 'drinking']),
    collect(['id' => 4, 'name' => 'belle', 'hobby' => 'cross-stitch']),
]);

$collection->pluckMany(['name', 'hobby']);

// returns a new Collection object:
// collect([
//     ['name' => 'matt', 'hobby' => 'coding'],
//     (object) ['name' => 'tomo', 'hobby' => 'cooking'],
//     ['name' => 'marco', 'hobby' => 'drinking'],
//     collect(['name' => 'belle', 'hobby' => 'cross-stitch']),
// ])
```

## Design decisions
* When an item implements the ArrayAccess interface, it's converted into a plain array. I felt like this was the most intuitive behaviour because it ensures the interface to access its keys stays the same.

## Impact
This shouldn't affect any existing macros as it's the addition of a self-contained new one.