### PR TITLE
Fix firstOrFail tests

### DIFF
--- a/tests/Macros/FirstOrFailTest.php
+++ b/tests/Macros/FirstOrFailTest.php
@@ -11,6 +11,11 @@ class FirstOrFailTest extends TestCase
     /** @test */
     public function it_returns_first_item_when_there_is_one()
     {
+        if (method_exists(Collection::class, 'firstOrFail')) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
         $result = Collection::make([1, 2, 3, 4])->firstOrFail();
 
         $this->assertEquals(1, $result);
@@ -19,8 +24,12 @@ class FirstOrFailTest extends TestCase
     /** @test */
     public function it_throws_exception_when_there_are_no_items()
     {
+        if (method_exists(Collection::class, 'firstOrFail')) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+        
         $this->expectException(CollectionItemNotFound::class);
-
         Collection::make()->firstOrFail();
     }
 }

--- a/tests/Macros/FirstOrFailTest.php
+++ b/tests/Macros/FirstOrFailTest.php
@@ -28,8 +28,9 @@ class FirstOrFailTest extends TestCase
             $this->expectNotToPerformAssertions();
             return;
         }
-        
+
         $this->expectException(CollectionItemNotFound::class);
+
         Collection::make()->firstOrFail();
     }
 }


### PR DESCRIPTION
The `FirstOrFailTest::it_throws_exception_when_there_are_no_items` was failing on master branch.

This is because Laravel added a firstOrFail method to Collections in Laravel 8.56:
https://github.com/laravel/framework/releases/tag/v8.56.0
https://github.com/laravel/framework/blob/beda5af8952ecac04aadfe9278d4b79d9135fadd/src/Illuminate/Collections/Collection.php#L1143

Methods take preference over macros, so the tests weren't running the firstOrFail macro in Laravel 8.56+ (and the same for Laravel 8.56+ users of laravel-collection-macros).

I've updated the tests to run only if the firstOrFail method doesn't exist.