### PR TITLE
Using slice to get the nth element

### DIFF
--- a/src/Macros/GetNth.php
+++ b/src/Macros/GetNth.php
@@ -17,7 +17,7 @@ class GetNth
     public function __invoke()
     {
         return function (int $nth) {
-            return $this->skip($nth - 1)->first();
+            return $this->slice($nth - 1, 1)->first();
         };
     }
 }


### PR DESCRIPTION
This PR changes the implementation of the GetNth macro, using `slice` instead of `skip`. 

I know that `skip` uses `slice` under the hood, but, using skip, it creates a new collection with all elements after the desired index. Imagine you have a collection with 1000 itens. If you want the 2nd element, using skip, it will create a new collection with 999 elements, and than, call first on this collection. Using `slice`, it will create a new collection with only one element, and call the `first` method on this collection. Since the `getNth` method does not returns a collection instance, it does not matter if the collection created has all elements after the `nth` element or just one, so we can reduce memory usage using slice.

```php
$collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);

$collection->skip(3)->values();  // [4, 5, 6, 7, 8]

$collection->skip(3)->first(); // 4

$collection->slice(3, 1)->values(); // [4]

$collection->slice(3, 1)->first(); // 4
```