### PR TITLE
Added recursive macro

### DIFF
--- a/src/CollectionMacroServiceProvider.php
+++ b/src/CollectionMacroServiceProvider.php
@@ -50,6 +50,7 @@ class CollectionMacroServiceProvider extends ServiceProvider
             'pluckMany' => \Spatie\CollectionMacros\Macros\PluckMany::class,
             'pluckToArray' => \Spatie\CollectionMacros\Macros\PluckToArray::class,
             'prioritize' => \Spatie\CollectionMacros\Macros\Prioritize::class,
+            'recursive' => \Spatie\CollectionMacros\Macros\Recursive::class,
             'rotate' => \Spatie\CollectionMacros\Macros\Rotate::class,
             'second' => \Spatie\CollectionMacros\Macros\Second::class,
             'sectionBy' => \Spatie\CollectionMacros\Macros\SectionBy::class,

--- a/src/Macros/Recursive.php
+++ b/src/Macros/Recursive.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Spatie\CollectionMacros\Macros;
+
+use Illuminate\Support\Collection;
+
+/**
+ * Recursivly convert arrays and objects within a multi-dimensional array to Collections
+ *
+ * @mixin \Illuminate\Support\Collection
+ *
+ * @return \Illuminate\Support\Collection
+ */
+class Recursive
+{
+    public function __invoke()
+    {
+        return function (): Collection {
+            return $this->map(function ($value) {
+                if (is_array($value) || is_object($value)) {
+                    return collect($value)->recursive();
+                }
+
+                return $value;
+            });
+        };
+    }
+}

--- a/tests/Macros/RecursiveTest.php
+++ b/tests/Macros/RecursiveTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test\Macros;
+
+use Illuminate\Support\Collection;
+use Spatie\CollectionMacros\Test\TestCase;
+
+class RecursiveTest extends TestCase
+{
+    /** @test */
+    public function it_coverts_child_arrays_to_collections()
+    {
+        $collection = Collection::make([
+            'child' => [
+                1, 2, 3, 'anotherchild' => [1, 2, 3]
+            ],
+        ])
+            ->recursive();
+
+        $this->assertInstanceOf(Collection::class, $collection['child']);
+        $this->assertInstanceOf(Collection::class, $collection['child']['anotherchild']);
+    }
+
+    /** @test */
+    public function it_coverts_child_objects_to_collections()
+    {
+        $collection = Collection::make([
+            'child' => (object) [1, 2, 3, 'anotherchild' => (object) [1, 2, 3]],
+        ])
+            ->recursive();
+
+        $this->assertInstanceOf(Collection::class, $collection['child']);
+        $this->assertInstanceOf(Collection::class, $collection['child']['anotherchild']);
+    }
+}


### PR DESCRIPTION
This PR adds a `recursive` macro that converts a collection's nested arrays and objects to Collections themselves. This is useful for multi-dimensional arrays where potentially all items need to be managed with Collection methods.

```php
collect(['child' => [1, 2, 3, 'anotherchild' => [1, 2, 3]]])
```

In this example, both `child` and `anotherchild` become collections.