### PR TITLE
Add recursive macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The package will automatically register itself.
 - [`pluckToArray`](#plucktoarray)
 - [`prioritize`](#prioritize)
 - [`rotate`](#rotate)
+- [`recursive`](#recursive)
 - [`sectionBy`](#sectionby)
 - [`simplePaginate`](#simplepaginate)
 - [`sliceBefore`](#slicebefore)
@@ -656,6 +657,20 @@ $rotate = $collection->rotate(1);
 $rotate->toArray();
 
 // [2, 3, 4, 5, 6, 1]
+```
+
+### `recursive`
+
+Convert an array and its children to collection using recursion.
+
+```php
+collect([
+  'item' => [
+     'children' => []
+  ]   
+])->recursive();
+
+// subsequent arrays is now collections
 ```
 
 ### `sectionBy`

--- a/src/CollectionMacroServiceProvider.php
+++ b/src/CollectionMacroServiceProvider.php
@@ -51,6 +51,7 @@ class CollectionMacroServiceProvider extends ServiceProvider
             'pluckToArray' => \Spatie\CollectionMacros\Macros\PluckToArray::class,
             'prioritize' => \Spatie\CollectionMacros\Macros\Prioritize::class,
             'rotate' => \Spatie\CollectionMacros\Macros\Rotate::class,
+            'recursive' => \Spatie\CollectionMacros\Macros\Recursive::class,
             'second' => \Spatie\CollectionMacros\Macros\Second::class,
             'sectionBy' => \Spatie\CollectionMacros\Macros\SectionBy::class,
             'seventh' => \Spatie\CollectionMacros\Macros\Seventh::class,

--- a/src/Macros/Recursive.php
+++ b/src/Macros/Recursive.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Spatie\CollectionMacros\Macros;
+
+/**
+ * Convert an array and its children to collection using recursion.
+ *
+ * @mixin \Illuminate\Support\Collection
+ *
+ * @return \Illuminate\Support\Collection
+ */
+class Recursive
+{
+    public function __invoke()
+    {
+        return function () {
+            return $this->map(
+                static function ($value) {
+                    if (is_array($value) || is_object($value)) {
+                        return collect($value)->recursive();
+                    }
+
+                    return $value;
+                }
+            );
+        };
+    }
+}

--- a/tests/Macros/RecursiveTest.php
+++ b/tests/Macros/RecursiveTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test\Macros;
+
+use Illuminate\Support\Collection;
+use Spatie\CollectionMacros\Test\TestCase;
+
+class RecursiveTest extends TestCase
+{
+    /** @test */
+    public function it_provides_recursive_macro()
+    {
+        $this->assertTrue(Collection::hasMacro('recursive'));
+    }
+
+    /** @test */
+    public function it_can_collect_recursive()
+    {
+        $collection = new Collection([
+            'item' => [
+                'children' => [
+                    'next' => [],
+                ],
+            ]
+        ]);
+
+        $expected = new Collection([
+            'item' => new Collection([
+                'children' => new Collection([
+                    'next' => new Collection()
+                ]),
+            ])
+        ]);
+
+        $this->assertEquals(
+            $expected,
+            $collection->recursive()
+        );
+    }
+}


### PR DESCRIPTION
### Good old recursive macro
This macro adds the possibility to collect subsequent arrays recursively.

![tinker](https://user-images.githubusercontent.com/37669560/141658801-4b299b7e-fcee-4450-95f3-29ada97d2e36.png)

This one was discussed across time at this **[gist](https://gist.github.com/brunogaspar/154fb2f99a7f83003ef35fd4b5655935)**
Not sure who is the original author is, but I think we should finally add it as @freekmurze suggested in the tweet:
https://twitter.com/freekmurze/status/1459209988212240391

I'm considering if should we add `whenEmpty()` to let people configure what to return if an array is empty?
Let me know if we can improve this in any possible way.