### PR TITLE
Add `getDeeply` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The package will automatically register itself.
 - [`firstOrFail`](#firstorfail)
 - [`firstOrPush`](#firstorpush)
 - [`fromPairs`](#frompairs)
+- [`getDeeply`](#getdeeply)
 - [`glob`](#glob)
 - [`groupByModel`](#groupbymodel)
 - [`head`](#head)
@@ -351,6 +352,23 @@ Transform a collection into an associative array form collection item.
 $collection = collect([['a', 'b'], ['c', 'd'], ['e', 'f']])->fromPairs();
 
 $collection->toArray(); // returns ['a' => 'b', 'c' => 'd', 'e' => 'f']
+```
+
+### `getDeeply`
+
+Returns an item from the collection with multidimensional data using "dot" notation.
+Works the same way as native Collection's `pull` method, but without removing an item from the collection.
+
+```php
+$collection = new Collection([
+    'foo' => [
+        'bar' => [
+            'baz' => 100,
+        ]
+    ]
+]);
+
+$collection->getDeeply('foo.bar.baz') // 100
 ```
 
 ### `glob`

--- a/src/CollectionMacroServiceProvider.php
+++ b/src/CollectionMacroServiceProvider.php
@@ -31,6 +31,7 @@ class CollectionMacroServiceProvider extends ServiceProvider
             'firstOrPush' => \Spatie\CollectionMacros\Macros\FirstOrPush::class,
             'fourth' => \Spatie\CollectionMacros\Macros\Fourth::class,
             'fromPairs' => \Spatie\CollectionMacros\Macros\FromPairs::class,
+            'getDeeply' => \Spatie\CollectionMacros\Macros\GetDeeply::class,
             'getNth' => \Spatie\CollectionMacros\Macros\GetNth::class,
             'glob' => \Spatie\CollectionMacros\Macros\Glob::class,
             'groupByModel' => \Spatie\CollectionMacros\Macros\GroupByModel::class,

--- a/src/Macros/GetDeeply.php
+++ b/src/Macros/GetDeeply.php
@@ -5,7 +5,7 @@ namespace Spatie\CollectionMacros\Macros;
 use Illuminate\Support\Arr;
 
 /***
- * Get the previous item from the collection.
+ * Get an item from the collection with multidimensional data using "dot" notation.
  *
  * @param int $nth
  * @param mixed $fallback

--- a/src/Macros/GetDeeply.php
+++ b/src/Macros/GetDeeply.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\CollectionMacros\Macros;
+
+use Illuminate\Support\Arr;
+
+/***
+ * Get the previous item from the collection.
+ *
+ * @param int $nth
+ * @param mixed $fallback
+ *
+ * @mixin \Illuminate\Support\Collection
+ *
+ * @return mixed
+ */
+class GetDeeply
+{
+    public function __invoke()
+    {
+        return function ($key, $default = null) {
+            return Arr::get($this->items, $key, $default);
+        };
+    }
+}

--- a/src/Macros/GetDeeply.php
+++ b/src/Macros/GetDeeply.php
@@ -7,8 +7,8 @@ use Illuminate\Support\Arr;
 /***
  * Get an item from the collection with multidimensional data using "dot" notation.
  *
- * @param int $nth
- * @param mixed $fallback
+ * @param mixed $key
+ * @param mixed $default
  *
  * @mixin \Illuminate\Support\Collection
  *

--- a/tests/Macros/GetDeeplyTest.php
+++ b/tests/Macros/GetDeeplyTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test\Macros;
+
+use Illuminate\Support\Collection;
+use Spatie\CollectionMacros\Test\TestCase;
+
+class GetDeeplyTest extends TestCase
+{
+    /** @test */
+    public function it_retrieves_item_from_collection()
+    {
+        $collection = new Collection(['foo', 'bar']);
+
+        $this->assertSame(
+            'foo',
+            $collection->getDeeply(0)
+        );
+    }
+
+    /** @test */
+    public function it_retrieves_item_from_collection_using_dot_notation()
+    {
+        $collection = new Collection([
+            'foo' => [
+                'bar' => [
+                    'baz' => 100,
+                ]
+            ]
+        ]);
+
+        $this->assertSame(
+            100,
+            $collection->getDeeply('foo.bar.baz')
+        );
+    }
+
+    /** @test */
+    public function it_doesnt_remove_item_from_collection()
+    {
+        $collection = new Collection(['foo', 'bar']);
+
+        $collection->getDeeply(0);
+
+        $this->assertEquals(
+            [
+                0 => 'foo',
+                1 => 'bar',
+            ],
+            $collection->all()
+        );
+    }
+
+    /** @test */
+    public function it_returns_default()
+    {
+        $collection = new Collection([]);
+
+        $this->assertSame(
+            'foo',
+            $collection->getDeeply(0, 'foo')
+        );
+    }
+}

--- a/tests/Macros/GetDeeplyTest.php
+++ b/tests/Macros/GetDeeplyTest.php
@@ -25,8 +25,8 @@ class GetDeeplyTest extends TestCase
             'foo' => [
                 'bar' => [
                     'baz' => 100,
-                ]
-            ]
+                ],
+            ],
         ]);
 
         $this->assertSame(


### PR DESCRIPTION
Always when we want to get the data from a collection with multidimensional arrays, it was a way to use `pull` or multidimensional collections with `->get()->get()` which is not very elegant. The pull works well, but it actually removes the item from the collection besides retrieving. Most times working in Laravel I wanted to use dot notation, but to leave the item in the collection as other parts of the application might want access that data as well. The new method `getDeeply` works in a similar way as `pull` (using dot notation), but without removing an item from the collection.