### PR TITLE
Remove extra * from Before macro

### DIFF
--- a/src/Macros/Before.php
+++ b/src/Macros/Before.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\CollectionMacros\Macros;
 
-/***
+/**
  * Get the previous item from the collection.
  *
  * @param mixed $currentItem


### PR DESCRIPTION
There is an extra * in the docblock that is preventing intellisense from reading properly. This PR removes the extra * to fix this issue.