### PR TITLE
Add `weightedRandom` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,7 +844,7 @@ collect(['sebastian@spatie.be', 'freek@spatie.be'])->validate('email'); // retur
 
 ### `weightedRandom`
 
-Returns a random item by a weight. In this example, the item with `a` has the most change to get picked, and the item with `c` the least.
+Returns a random item by a weight. In this example, the item with `a` has the most chance to get picked, and the item with `c` the least.
 
 ```php
 // pass the field name that should be used as a weight
@@ -859,8 +859,6 @@ $randomItem = collect([
 Alternatively, you can pass a callable to get the weight.
 
 ```php
-// pass the field name that should be used as a weight
-
 $randomItem = collect([
     ['value' => 'a', 'weight' => 30],
     ['value' => 'b', 'weight' => 20],

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The package will automatically register itself.
 - [`toPairs`](#topairs)
 - [`transpose`](#transpose)
 - [`validate`](#validate)
+- [`weightedRandom`](#weightedRandom)
 - [`withSize`](#withsize)
 
 ### `after`
@@ -840,6 +841,36 @@ collect(['foo', 'foo'])->validate(function ($item) {
 collect(['sebastian@spatie.be', 'bla'])->validate('email'); // returns false
 collect(['sebastian@spatie.be', 'freek@spatie.be'])->validate('email'); // returns true
 ```
+
+### `weightedRandom`
+
+Returns a random item by a weight. In this example, the item with `a` has the most change to get picked, and the item with `c` the least.
+
+```php
+// pass the field name that should be used as a weight
+
+$randomItem = collect([
+    ['value' => 'a', 'weight' => 30],
+    ['value' => 'b', 'weight' => 20],
+    ['value' => 'c', 'weight' => 10],
+])->weightedRandom('weight');
+```
+
+Alternatively, you can pass a callable to get the weight.
+
+```php
+// pass the field name that should be used as a weight
+
+$randomItem = collect([
+    ['value' => 'a', 'weight' => 30],
+    ['value' => 'b', 'weight' => 20],
+    ['value' => 'c', 'weight' => 10],
+])->weightedRandom(function(array $item) {
+   return $item['weight'];
+});
+```
+
+
 
 ### `withSize`
 

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "mockery/mockery": "^1.4.2",
         "orchestra/testbench": "^6.23|^7.0",
         "phpunit/phpunit": "^9.4.4",
+        "spatie/laravel-ray": "^1.29",
         "symfony/stopwatch": "^5.2|^6.0"
     },
     "suggest": {

--- a/src/CollectionMacroServiceProvider.php
+++ b/src/CollectionMacroServiceProvider.php
@@ -66,6 +66,7 @@ class CollectionMacroServiceProvider extends ServiceProvider
             'transpose' => \Spatie\CollectionMacros\Macros\Transpose::class,
             'try' => \Spatie\CollectionMacros\Macros\TryCatch::class,
             'validate' => \Spatie\CollectionMacros\Macros\Validate::class,
+            'weightedRandom' => \Spatie\CollectionMacros\Macros\WeightedRandom::class,
             'withSize' => \Spatie\CollectionMacros\Macros\WithSize::class,
         ];
     }

--- a/src/Macros/WeightedRandom.php
+++ b/src/Macros/WeightedRandom.php
@@ -11,7 +11,7 @@ class WeightedRandom
                 $attributeName = $weightAttribute;
 
                 $weightAttribute = function ($item) use ($attributeName) {
-                    return $item[$attributeName];
+                    return data_get($attributeName, $item);
                 };
             }
 

--- a/src/Macros/WeightedRandom.php
+++ b/src/Macros/WeightedRandom.php
@@ -11,7 +11,7 @@ class WeightedRandom
                 $attributeName = $weightAttribute;
 
                 $weightAttribute = function ($item) use ($attributeName) {
-                    return data_get($attributeName, $item);
+                    return data_get($item, $attributeName);
                 };
             }
 

--- a/src/Macros/WeightedRandom.php
+++ b/src/Macros/WeightedRandom.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Spatie\CollectionMacros\Macros;
+
+class WeightedRandom
+{
+    public function __invoke()
+    {
+        return function (callable|string $weightAttribute, $default = null) {
+            if (is_string($weightAttribute)) {
+                $attributeName = $weightAttribute;
+
+                $weightAttribute = function($item) use ($attributeName) {
+                    return $item[$attributeName];
+                };
+            }
+
+            $range = 0;
+
+            $weightedItems = collect($this->items)
+                ->map(function ($item) use ($weightAttribute, &$range) {
+                    $weightAttribute = $weightAttribute($item);
+                    $range += $weightAttribute;
+
+                    return [
+                        'range' => $range,
+                        'weight' => $weightAttribute,
+                        'item' => $item,
+                    ];
+                })
+                ->filter(function(array $weightedItem) {
+                    return $weightedItem['weight'] > 0;
+                });
+
+            if ($weightedItems->isEmpty()) {
+                return $this->random();
+            }
+
+
+            $randomNumber = rand(1, $range);
+
+            $itemAndRange = $weightedItems
+                ->first(function ($weightedItem) use ($randomNumber) {
+                    return $weightedItem['range'] >= $randomNumber;
+                });
+
+            return $itemAndRange['item'] ?? $default;
+        };
+    }
+}

--- a/tests/Macros/WeightedRandomTest.php
+++ b/tests/Macros/WeightedRandomTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test\Macros;
+
+use Illuminate\Support\Collection;
+use Spatie\CollectionMacros\Test\TestCase;
+
+class WeightedRandom extends TestCase
+{
+    /** @test */
+    public function it_will_probably_return_the_heaviest_item_most()
+    {
+        $items = collect([
+            ['value' => 'a', 'weight' => 1],
+            ['value' => 'b', 'weight' => 10],
+            ['value' => 'c', 'weight' => 1],
+        ]);
+
+        $mostPopularValue = Collection::range(0, 1000)
+            ->map(function() use ($items) {
+                return $items->weightedRandom(function(array $item) {
+                    return $item['weight'];
+                });
+            })
+            ->groupBy('value')
+            ->map
+            ->count()
+            ->sortDesc()
+            ->flip()
+            ->first();
+
+        $this->assertEquals('b', $mostPopularValue);
+    }
+
+    /** @test */
+    public function it_will_not_pick_a_value_without_a_weight()
+    {
+        $items = collect([
+            ['value' => 'a', 'weight' => 0],
+            ['value' => 'b', 'weight' => 0],
+            ['value' => 'c', 'weight' => 1],
+            ['value' => 'c', 'weight' => 0],
+        ]);
+
+        $pickedItem = $items->weightedRandom(fn(array $item) => $item['weight']);
+
+        $this->assertEquals('c', $pickedItem['value']);
+    }
+
+    /** @test */
+    public function it_will_pick_a_random_value_when_all_values_are_zero()
+    {
+        $items = collect([
+            ['value' => 'a', 'weight' => 0],
+            ['value' => 'b', 'weight' => 0],
+            ['value' => 'c', 'weight' => 0],
+        ]);
+
+        $this->assertIsArray($items->weightedRandom(fn(array $item) => $item['weight']));
+    }
+
+    /** @test */
+    public function it_can_pick_a_weighted_random_by_attribute_name()
+    {
+        $items = collect([
+            ['value' => 'a', 'weight' => 0],
+            ['value' => 'b', 'weight' => 1],
+            ['value' => 'c', 'weight' => 0],
+        ]);
+
+        $item = ($items->weightedRandom('weight'));
+
+        $this->assertEquals('b', $item['value']);
+    }
+}

--- a/tests/Macros/WeightedRandomTest.php
+++ b/tests/Macros/WeightedRandomTest.php
@@ -5,7 +5,7 @@ namespace Spatie\CollectionMacros\Test\Macros;
 use Illuminate\Support\Collection;
 use Spatie\CollectionMacros\Test\TestCase;
 
-class WeightedRandom extends TestCase
+class WeightedRandomTest extends TestCase
 {
     /** @test */
     public function it_will_probably_return_the_heaviest_item_most()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,8 @@ abstract class TestCase extends BaseTestCase
     protected function setUp(): void
     {
         $this->createDummyprovider()->register();
+
+        ray()->newScreen($this->getName());
     }
 
     protected function createDummyprovider(): CollectionMacroServiceProvider


### PR DESCRIPTION
Returns a random item by a weight. In this example, the item with `a` has the most chance to get picked, and the item with `c` the least.

```php
$randomItem = collect([
    ['value' => 'a', 'weight' => 30],
    ['value' => 'b', 'weight' => 20],
    ['value' => 'c', 'weight' => 10],
])->weightedRandom(function(array $item) {
   return $item['weight'];
});
```