### PR TITLE
Ignore Closures in `recursive` macro

### DIFF
--- a/src/Macros/Recursive.php
+++ b/src/Macros/Recursive.php
@@ -17,7 +17,7 @@ class Recursive
     {
         return function (): Collection {
             return $this->map(function ($value) {
-                if (is_array($value) || is_object($value)) {
+                if (!($value instanceof \Closure) && (is_array($value) || is_object($value))) {
                     return collect($value)->recursive();
                 }
 

--- a/tests/Macros/RecursiveTest.php
+++ b/tests/Macros/RecursiveTest.php
@@ -32,4 +32,19 @@ class RecursiveTest extends TestCase
         $this->assertInstanceOf(Collection::class, $collection['child']);
         $this->assertInstanceOf(Collection::class, $collection['child']['anotherchild']);
     }
+
+    /** @test */
+    public function it_ignores_closures()
+    {
+        $collection = Collection::make([
+            'child' => [
+                1, 2, 3, 'anotherchild' => fn() => 1 + 2,
+            ],
+        ])
+            ->recursive();
+
+        $this->assertInstanceOf(Collection::class, $collection['child']);
+        $this->assertInstanceOf(\Closure::class, $collection['child']['anotherchild']);
+        $this->assertNotInstanceOf(Collection::class, $collection['child']['anotherchild']);
+    }
 }


### PR DESCRIPTION
I experienced a case where my collections had a closure in them and thus the `recursive` macro would fail.  This PR makes it so that the recursion does not go descend into `Closure` values.

Example Case:

```php
$collection = collect([
    1,
    2,
    3,
    'closure_child' => fn() => 1 + 2,
    5,
])->recursive();
```