### PR TITLE
Add `hasNotNull` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The package will automatically register itself.
 - [`fromPairs`](#frompairs)
 - [`glob`](#glob)
 - [`groupByModel`](#groupbymodel)
+- [`hasNotNull`](#hasnotnull)
 - [`head`](#head)
 - [`if`](#if)
 - [`ifAny`](#ifany)
@@ -380,6 +381,17 @@ $posts->groupByModel('category');
 ```
 
 Full signature: `groupByModel($callback, $preserveKeys, $modelKey, $itemsKey)`
+
+### `hasNotNull`
+
+Determines if a given key exists in the Collection and its value is not null. (Uses the `has` and `get` collection methods.)
+
+```php
+collect(['foo'])->hasNotNull('foo'); // returns false
+collect(['foo' => null])->hasNotNull('foo'); // returns false
+
+collect(['foo' => 'bar'])->hasNotNull('foo'); // returns true
+```
 
 ### `head`
 

--- a/src/CollectionMacroServiceProvider.php
+++ b/src/CollectionMacroServiceProvider.php
@@ -34,6 +34,7 @@ class CollectionMacroServiceProvider extends ServiceProvider
             'getNth' => \Spatie\CollectionMacros\Macros\GetNth::class,
             'glob' => \Spatie\CollectionMacros\Macros\Glob::class,
             'groupByModel' => \Spatie\CollectionMacros\Macros\GroupByModel::class,
+            'hasNotNull' => \Spatie\CollectionMacros\Macros\HasNotNull::class,
             'head' => \Spatie\CollectionMacros\Macros\Head::class,
             'if' => \Spatie\CollectionMacros\Macros\IfMacro::class,
             'ifAny' => \Spatie\CollectionMacros\Macros\IfAny::class,

--- a/src/Macros/HasNotNull.php
+++ b/src/Macros/HasNotNull.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\CollectionMacros\Macros;
+
+use Illuminate\Support\Collection;
+
+/**
+ * Determines if a given key exists in the Collection and its value is not null.
+ * (Uses the `has` and `get` collection methods.)
+ *
+ * @mixin \Illuminate\Support\Collection
+ *
+ * @return bool
+ */
+class HasNotNull
+{
+    public function __invoke()
+    {
+        return function ($key): bool {
+            return $this->has($key) && $this->get($key) != null;
+        };
+    }
+}

--- a/tests/Macros/HasNotNullTest.php
+++ b/tests/Macros/HasNotNullTest.php
@@ -11,8 +11,8 @@ class HasNotNullTest extends TestCase
     /** @test */
     public function it_can_check_if_a_key_exists_and_is_not_null()
     {
-        $this->assertFalse(Collection::make(['foo'])->hasNotNull());
-        $this->assertFalse(Collection::make(['foo' => null])->hasNotNull());
-        $this->assertTrue(Collection::make(['foo' => 'bar'])->hasNotNull());
+        $this->assertFalse(Collection::make(['foo'])->hasNotNull('foo'));
+        $this->assertFalse(Collection::make(['foo' => null])->hasNotNull('foo'));
+        $this->assertTrue(Collection::make(['foo' => 'bar'])->hasNotNull('foo'));
     }
 }

--- a/tests/Macros/HasNotNullTest.php
+++ b/tests/Macros/HasNotNullTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test\Macros;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Collection;
+use Spatie\CollectionMacros\Test\TestCase;
+
+class HasNotNullTest extends TestCase
+{
+    /** @test */
+    public function it_can_check_if_a_key_exists_and_is_not_null()
+    {
+        $this->assertFalse(Collection::make(['foo'])->hasNotNull());
+        $this->assertFalse(Collection::make(['foo' => null])->hasNotNull());
+        $this->assertTrue(Collection::make(['foo' => 'bar'])->hasNotNull());
+    }
+}


### PR DESCRIPTION
I found this `hasNotNull` macro to be very helpful in my application as it follows the Laravel naming convention that already exists within Eloquent models and also allows for shorter code.  Also, because of the internal use of `has` and `get` keys with dot notation are fully supported.

Old:
```php
$collection = collect([
    'foo' => null,
    'animal' => 'dog',
]);

if($collection->has('foo') && $collection->get('foo') != null) {
    //Do true stuff
}
```

New:
```php
$collection = collect([
    'foo' => null,
    'animal' => 'dog',
]);

if($collection->hasNotNull('foo')) {
    //Do true stuff
}
```