### PR TITLE
Add `twentyFirst` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The package will automatically register itself.
     - [`eighth`](#eighth)
     - [`ninth`](#ninth)
     - [`tenth`](#tenth)
+    - [`twentyFirst`](#twentyFirst)
     - [`getNth`](#getNth)
 - [`before`](#before)
 - [`catch`](#catch)
@@ -203,6 +204,15 @@ Retrieve item at the tenth index.
 $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
 $data->tenth(); // 10
+```
+
+### `twentyFirst`
+Retrieve item at the twenty first index.
+
+```php
+$data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]);
+
+$data->twentyFirst(); // 21
 ```
 
 ### `getNth`

--- a/src/CollectionMacroServiceProvider.php
+++ b/src/CollectionMacroServiceProvider.php
@@ -64,6 +64,7 @@ class CollectionMacroServiceProvider extends ServiceProvider
             'third' => \Spatie\CollectionMacros\Macros\Third::class,
             'toPairs' => \Spatie\CollectionMacros\Macros\ToPairs::class,
             'transpose' => \Spatie\CollectionMacros\Macros\Transpose::class,
+            'twentyFirst' => \Spatie\CollectionMacros\Macros\TwentyFirst::class,
             'try' => \Spatie\CollectionMacros\Macros\TryCatch::class,
             'validate' => \Spatie\CollectionMacros\Macros\Validate::class,
             'weightedRandom' => \Spatie\CollectionMacros\Macros\WeightedRandom::class,

--- a/src/Macros/TwentyFirst.php
+++ b/src/Macros/TwentyFirst.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\CollectionMacros\Macros;
+
+class TwentyFirst
+{
+    public function __invoke()
+    {
+        return function () {
+            return $this->skip(20)->first();
+        };
+    }
+}


### PR DESCRIPTION
Hello,
I think we should add `twentyFirst` method to `Collection`, to be able to fetch the twenty-first element.

I guess it is really important thing, cause all know that:
> not pontoon does bring you trouble, but when eleven's getting ace.

This PR fixes this unfortunate misunderstanding.