### PR TITLE
Ignore IDE folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 build
 composer.lock
 docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea
+/.vscode
 build
 composer.lock
 docs


### PR DESCRIPTION
Each time I want to contribute I face a lot of IDE files available to commit. It doesn't have to be this way though.
This PR adds `.idea` (PHPStorm) and `.vscode` (VSCode) folders to `.gitignore`.