### PR TITLE
Add `Nullify` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The package will automatically register itself.
 - [`insertBefore`](#insertbefore)
 - [`insertBeforeKey`](#insertbeforekey)
 - [`none`](#none)
+- [`nullify`](#nullify)
 - [`paginate`](#paginate)
 - [`parallelMap`](#parallelmap)
 - [`path`](#path)
@@ -542,6 +543,66 @@ collect([['name' => 'foo']])->none('name', 'foo'); // returns false
 collect(['name' => 'foo'])->none(function ($key, $value) {
    return $key === 'name' && $value === 'bar';
 }); // returns true
+```
+
+### `nullify`
+
+Checks whether a collection has blank values and sets the values null if so.
+```php
+collect([
+    'first_name'  => null,
+    'last_name'   => '',
+    'full_name'   => collect(),
+    'nick_name'   => [],
+    'correct_one' => 'Correct one!',
+])->nullify()->toArray()
+
+// Returns:
+// array:5 [
+//   'first_name'  => null,
+//   'last_name'   => null,
+//   'full_name'   => null,
+//   'nick_name'   => null,
+//   'correct_one' => 'Correct one!',
+// ]
+
+collect([
+    'first_name' => [
+        'parts'  => '',
+    ],
+    'last_name'  => collect([
+        'parts'  => [],
+    ]),
+    'full_name'  => [
+        'parts'  => collect([
+            'additional_part' => '',
+        ]),
+    ],
+])->nullify()
+
+// Returns:
+// Illuminate\Support\Collection^ {#936
+//  #items: array:3 [
+//    "first_name" => array:2 [
+//      "parts" => null
+//    ]
+//    "last_name" => Illuminate\Support\Collection^ {#942
+//      #items: array:2 [
+//        "parts" => null
+//      ]
+//      #escapeWhenCastingToString: false
+//    }
+//    "full_name" => array:2 [
+//      "parts" => Illuminate\Support\Collection^ {#941
+//        #items: array:1 [
+//          "additional_part" => null
+//        ]
+//        #escapeWhenCastingToString: false
+//      }
+//    ]
+//  ]
+//  #escapeWhenCastingToString: false
+// }
 ```
 
 ### `paginate`

--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ collect([
     'full_name'   => collect(),
     'nick_name'   => [],
     'correct_one' => 'Correct one!',
-])->nullify()->toArray()
+])->nullify()->toArray();
 
 // Returns:
 // array:5 [
@@ -578,7 +578,7 @@ collect([
             'additional_part' => '',
         ]),
     ],
-])->nullify()
+])->nullify();
 
 // Returns:
 // Illuminate\Support\Collection^ {#936

--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ collect(['name' => 'foo'])->none(function ($key, $value) {
 ### `nullify`
 
 Checks whether a collection has blank values and sets the values null if so.
+
 ```php
 collect([
     'first_name'  => null,

--- a/README.md
+++ b/README.md
@@ -576,36 +576,27 @@ collect([
     'last_name'  => collect([
         'parts'  => [],
     ]),
-    'full_name'  => [
+    'full_name'  => collect([
         'parts'  => collect([
             'additional_part' => '',
         ]),
-    ],
-])->nullify();
+    ]),
+])->nullify()->toArray();
 
 // Returns:
-// Illuminate\Support\Collection^ {#936
-//  #items: array:3 [
-//    "first_name" => array:2 [
-//      "parts" => null
-//    ]
-//    "last_name" => Illuminate\Support\Collection^ {#942
-//      #items: array:2 [
-//        "parts" => null
-//      ]
-//      #escapeWhenCastingToString: false
-//    }
-//    "full_name" => array:2 [
-//      "parts" => Illuminate\Support\Collection^ {#941
-//        #items: array:1 [
-//          "additional_part" => null
-//        ]
-//        #escapeWhenCastingToString: false
-//      }
+// array:3 [
+//  "first_name" => array:1 [
+//    "parts" => null
+//  ]
+//  "last_name" => array:1 [
+//    "parts" => null
+//  ]
+//  "full_name" => array:1 [
+//    "parts" => array:1 [
+//      "additional_part" => null
 //    ]
 //  ]
-//  #escapeWhenCastingToString: false
-// }
+// ]
 ```
 
 ### `paginate`

--- a/README.md
+++ b/README.md
@@ -554,6 +554,7 @@ collect([
     'last_name'   => '',
     'full_name'   => collect(),
     'nick_name'   => [],
+    'countable'   => new \SplObjectStorage,
     'correct_one' => 'Correct one!',
 ])->nullify()->toArray();
 
@@ -563,6 +564,7 @@ collect([
 //   'last_name'   => null,
 //   'full_name'   => null,
 //   'nick_name'   => null,
+//   'countable'   => null,
 //   'correct_one' => 'Correct one!',
 // ]
 

--- a/src/CollectionMacroServiceProvider.php
+++ b/src/CollectionMacroServiceProvider.php
@@ -45,6 +45,7 @@ class CollectionMacroServiceProvider extends ServiceProvider
             'insertBeforeKey' => \Spatie\CollectionMacros\Macros\InsertBeforeKey::class,
             'ninth' => \Spatie\CollectionMacros\Macros\Ninth::class,
             'none' => \Spatie\CollectionMacros\Macros\None::class,
+            'nullify' => \Spatie\CollectionMacros\Macros\Nullify::class,
             'paginate' => \Spatie\CollectionMacros\Macros\Paginate::class,
             'parallelMap' => \Spatie\CollectionMacros\Macros\ParallelMap::class,
             'path' => \Spatie\CollectionMacros\Macros\Path::class,

--- a/src/Macros/Nullify.php
+++ b/src/Macros/Nullify.php
@@ -20,23 +20,21 @@ class Nullify
     {
         return function () {
             return $this->map(
-                fn ($value) => ! blank($value)
-                    ? (function () use ($value) {
-                        if ((is_array($value) || $value instanceof \ArrayAccess) && is_iterable($value)) {
-                            foreach ($value as $key => $nestedValue) {
-                                if (blank($nestedValue)) {
-                                    $value[$key] = null;
-                                }
+                fn ($value) => blank($value) ? null : (function () use ($value) {
+                    if (is_iterable($value)) {
+                        foreach ($value as $key => $nestedValue) {
+                            if (blank($nestedValue)) {
+                                $value[$key] = null;
+                            }
 
-                                if ($nestedValue instanceof Collection) {
-                                    $value[$key] = $nestedValue->nullify();
-                                }
+                            if ($nestedValue instanceof Collection) {
+                                $value[$key] = $nestedValue->nullify();
                             }
                         }
+                    }
 
-                        return $value;
-                    })()
-                    : null
+                    return $value;
+                })()
             );
         };
     }

--- a/src/Macros/Nullify.php
+++ b/src/Macros/Nullify.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Spatie\CollectionMacros\Macros;
+
+use ArrayAccess;
+
+/**
+ * Checks whether a collection has blank
+ * values and sets the values null if so.
+ *
+ * @mixin \Illuminate\Support\Collection
+ *
+ * @return \Illuminate\Support\Collection
+ *
+ */
+class Nullify
+{
+    public function __invoke()
+    {
+        return function () {
+            return $this->map(
+                fn ($value) => ! blank($value)
+                    ? (function () use ($value) {
+                        if (is_array($value) || $value instanceof ArrayAccess) {
+                            foreach ($value as $key => $nestedValue) {
+                                if (blank($nestedValue)) {
+                                    $value[$key] = null;
+                                }
+                            }
+                        }
+
+                        return $value;
+                    })()
+                    : null
+            );
+        };
+    }
+}

--- a/src/Macros/Nullify.php
+++ b/src/Macros/Nullify.php
@@ -21,7 +21,7 @@ class Nullify
             return $this->map(
                 fn ($value) => ! blank($value)
                     ? (function () use ($value) {
-                        if (is_array($value) || $value instanceof ArrayAccess) {
+                        if ((is_array($value) || $value instanceof \ArrayAccess) && is_iterable($value)) {
                             foreach ($value as $key => $nestedValue) {
                                 if (blank($nestedValue)) {
                                     $value[$key] = null;

--- a/src/Macros/Nullify.php
+++ b/src/Macros/Nullify.php
@@ -3,6 +3,7 @@
 namespace Spatie\CollectionMacros\Macros;
 
 use ArrayAccess;
+use Illuminate\Support\Collection;
 
 /**
  * Checks whether a collection has blank
@@ -23,6 +24,10 @@ class Nullify
                     ? (function () use ($value) {
                         if ((is_array($value) || $value instanceof \ArrayAccess) && is_iterable($value)) {
                             foreach ($value as $key => $nestedValue) {
+                                if ($nestedValue instanceof Collection) {
+                                    $value[$key] = $nestedValue->nullify();
+                                }
+
                                 if (blank($nestedValue)) {
                                     $value[$key] = null;
                                 }

--- a/src/Macros/Nullify.php
+++ b/src/Macros/Nullify.php
@@ -24,12 +24,12 @@ class Nullify
                     ? (function () use ($value) {
                         if ((is_array($value) || $value instanceof \ArrayAccess) && is_iterable($value)) {
                             foreach ($value as $key => $nestedValue) {
-                                if ($nestedValue instanceof Collection) {
-                                    $value[$key] = $nestedValue->nullify();
-                                }
-
                                 if (blank($nestedValue)) {
                                     $value[$key] = null;
+                                }
+
+                                if ($nestedValue instanceof Collection) {
+                                    $value[$key] = $nestedValue->nullify();
                                 }
                             }
                         }

--- a/src/Macros/Nullify.php
+++ b/src/Macros/Nullify.php
@@ -22,13 +22,13 @@ class Nullify
             return $this->map(
                 fn ($value) => blank($value) ? null : (function () use ($value) {
                     if (is_iterable($value)) {
-                        foreach ($value as $key => $nestedValue) {
-                            if (blank($nestedValue)) {
+                        foreach ($value as $key => $nested) {
+                            if (blank($nested)) {
                                 $value[$key] = null;
                             }
 
-                            if ($nestedValue instanceof Collection) {
-                                $value[$key] = $nestedValue->nullify();
+                            if ($nested instanceof Collection) {
+                                $value[$key] = $nested->nullify();
                             }
                         }
                     }

--- a/tests/Macros/NullifyTest.php
+++ b/tests/Macros/NullifyTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\CollectionMacros\Test\Macros;
 
+use ArrayIterator;
 use Illuminate\Support\Collection;
 use Spatie\CollectionMacros\Test\TestCase;
 use SplObjectStorage;
@@ -63,6 +64,26 @@ class NullifyTest extends TestCase
             'full_name'  => ['first_part' => true, 'last_part'  => collect(['additional_part' => null])],
         ]);
 
+        $this->assertEquals($expected, $nullified);
+    }
+
+    /** @test */
+    public function test_array_iterator_behaves_as_expected_when_nullify()
+    {
+        $nullified = Collection::make(['iterator' => new ArrayIterator([1, 2, 3])])->nullify();
+        $expected  = Collection::make(['iterator' => new ArrayIterator([1, 2, 3])]);
+        $this->assertEquals($expected, $nullified);
+
+        $nullified = Collection::make(['iterator' => new ArrayIterator])->nullify();
+        $expected  = Collection::make(['iterator' => null]);
+        $this->assertEquals($expected, $nullified);
+    }
+
+    /** @test */
+    public function test_generators_passes_through_nullify()
+    {
+        $nullified = Collection::make(['generator' => (fn () => yield 0)()])->nullify();
+        $expected  = Collection::make(['generator' => (fn () => yield 0)()]);
         $this->assertEquals($expected, $nullified);
     }
 }

--- a/tests/Macros/NullifyTest.php
+++ b/tests/Macros/NullifyTest.php
@@ -4,6 +4,7 @@ namespace Spatie\CollectionMacros\Test\Macros;
 
 use Illuminate\Support\Collection;
 use Spatie\CollectionMacros\Test\TestCase;
+use SplObjectStorage;
 
 class NullifyTest extends TestCase
 {
@@ -15,6 +16,7 @@ class NullifyTest extends TestCase
             'last_name'   => '',
             'full_name'   => collect(),
             'nick_name'   => [],
+            'countable'   => new SplObjectStorage,
             'correct_one' => 'Correct one!',
         ])->nullify()->toArray();
 
@@ -23,6 +25,7 @@ class NullifyTest extends TestCase
             'last_name'   => null,
             'full_name'   => null,
             'nick_name'   => null,
+            'countable'   => null,
             'correct_one' => 'Correct one!',
         ], $result);
     }

--- a/tests/Macros/NullifyTest.php
+++ b/tests/Macros/NullifyTest.php
@@ -13,19 +13,19 @@ class NullifyTest extends TestCase
     public function it_can_nullify_values_in_collection()
     {
         $result = Collection::make([
-            'first_name'  => null,
-            'last_name'   => '',
-            'full_name'   => collect(),
-            'nick_name'   => [],
-            'countable'   => new SplObjectStorage,
+            'null'        => null,
+            'empty'       => '',
+            'array'       => [],
+            'collection'  => collect(),
+            'countable'   => new \SplObjectStorage,
             'correct_one' => 'Correct one!',
         ])->nullify()->toArray();
 
         $this->assertSame([
-            'first_name'  => null,
-            'last_name'   => null,
-            'full_name'   => null,
-            'nick_name'   => null,
+            'null'        => null,
+            'empty'       => null,
+            'array'       => null,
+            'collection'  => null,
             'countable'   => null,
             'correct_one' => 'Correct one!',
         ], $result);

--- a/tests/Macros/NullifyTest.php
+++ b/tests/Macros/NullifyTest.php
@@ -35,10 +35,10 @@ class NullifyTest extends TestCase
     public function it_can_nullify_values_in_collection_with_nested_array_access()
     {
         $result = Collection::make([
-            'test'       => new \SplObjectStorage,
+            'test'       => new SplObjectStorage,
             'first_name' => collect(['first_part' => false, 'last_part' => '']),
             'last_name'  => collect(['first_part' => true, 'last_part' => []]),
-            'full_name'  => collect(['first_part' => new \SplObjectStorage, 'last_part' => collect(['additional_part' => ''])]),
+            'full_name'  => collect(['first_part' => new SplObjectStorage, 'last_part' => collect(['additional_part' => ''])]),
         ])->nullify()->toArray();
 
         $this->assertSame([

--- a/tests/Macros/NullifyTest.php
+++ b/tests/Macros/NullifyTest.php
@@ -34,37 +34,17 @@ class NullifyTest extends TestCase
     public function it_can_nullify_values_in_collection_with_nested_array_access()
     {
         $result = Collection::make([
-            'first_name' => collect([
-                'first_part' => false,
-                'last_part'  => '',
-            ]),
-            'last_name'  => collect([
-                'first_part' => false,
-                'last_part'  => [],
-            ]),
-            'full_name'  => collect([
-                'first_part' => true,
-                'last_part'  => collect([
-                    'additional_part' => '',
-                ]),
-            ]),
+            'test'       => new \SplObjectStorage,
+            'first_name' => collect(['first_part' => false, 'last_part' => '']),
+            'last_name'  => collect(['first_part' => true, 'last_part' => []]),
+            'full_name'  => collect(['first_part' => new \SplObjectStorage, 'last_part' => collect(['additional_part' => ''])]),
         ])->nullify()->toArray();
 
         $this->assertEquals([
-            'first_name' => [
-                'first_part' => false,
-                'last_part'  => null,
-            ],
-            'last_name'  => [
-                'first_part' => false,
-                'last_part'  => null,
-            ],
-            'full_name'  => [
-                'first_part' => true,
-                'last_part'  => [
-                    'additional_part' => null,
-                ],
-            ],
+            'test'       => null,
+            'first_name' => ['first_part' => false, 'last_part' => null],
+            'last_name'  => ['first_part' => true, 'last_part' => null],
+            'full_name'  => ['first_part' => null, 'last_part' => ['additional_part' => null]],
         ], $result);
     }
 
@@ -72,37 +52,15 @@ class NullifyTest extends TestCase
     public function it_can_nullify_values_in_collection_without_converting_to_array()
     {
         $nullified = Collection::make([
-            'first_name' => [
-                'first_part' => false,
-                'last_part'  => '',
-            ],
-            'last_name'  => collect([
-                'first_part' => false,
-                'last_part'  => [],
-            ]),
-            'full_name'  => [
-                'first_part' => true,
-                'last_part'  => collect([
-                    'additional_part' => '',
-                ]),
-            ],
+            'first_name' => ['first_part' => false, 'last_part'  => ''],
+            'last_name'  => collect(['first_part' => false, 'last_part'  => []]),
+            'full_name'  => ['first_part' => true, 'last_part'  => collect(['additional_part' => ''])],
         ])->nullify();
 
         $expected = Collection::make([
-            'first_name' => [
-                'first_part' => false,
-                'last_part'  => null,
-            ],
-            'last_name'  => collect([
-                'first_part' => false,
-                'last_part'  => null,
-            ]),
-            'full_name'  => [
-                'first_part' => true,
-                'last_part'  => collect([
-                    'additional_part' => null,
-                ]),
-            ],
+            'first_name' => ['first_part' => false, 'last_part'  => null],
+            'last_name'  => collect(['first_part' => false, 'last_part'  => null]),
+            'full_name'  => ['first_part' => true, 'last_part'  => collect(['additional_part' => null])],
         ]);
 
         $this->assertEquals($expected, $nullified);

--- a/tests/Macros/NullifyTest.php
+++ b/tests/Macros/NullifyTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test\Macros;
+
+use Illuminate\Support\Collection;
+use Spatie\CollectionMacros\Test\TestCase;
+
+class NullifyTest extends TestCase
+{
+    /** @test */
+    public function it_can_nullify_values_in_collection()
+    {
+        $result = Collection::make([
+            'first_name'  => null,
+            'last_name'   => '',
+            'full_name'   => collect(),
+            'nick_name'   => [],
+            'correct_one' => 'Correct one!',
+        ])->nullify()->toArray();
+
+        $this->assertSame([
+            'first_name'  => null,
+            'last_name'   => null,
+            'full_name'   => null,
+            'nick_name'   => null,
+            'correct_one' => 'Correct one!',
+        ], $result);
+    }
+
+    /** @test */
+    public function it_can_nullify_values_in_collection_with_nested_array_access()
+    {
+        $result = Collection::make([
+            'first_name' => collect([
+                'first_part' => false,
+                'last_part'  => '',
+            ]),
+            'last_name'  => collect([
+                'first_part' => false,
+                'last_part'  => [],
+            ]),
+            'full_name'  => collect([
+                'first_part' => true,
+                'last_part'  => collect([
+                    'additional_part' => '',
+                ]),
+            ]),
+        ])->nullify()->toArray();
+
+        $this->assertEquals([
+            'first_name' => [
+                'first_part' => false,
+                'last_part'  => null,
+            ],
+            'last_name'  => [
+                'first_part' => false,
+                'last_part'  => null,
+            ],
+            'full_name'  => [
+                'first_part' => true,
+                'last_part'  => [
+                    'additional_part' => null,
+                ],
+            ],
+        ], $result);
+    }
+
+    /** @test */
+    public function it_can_nullify_values_in_collection_without_converting_to_array()
+    {
+        $nullified = Collection::make([
+            'first_name' => [
+                'first_part' => false,
+                'last_part'  => '',
+            ],
+            'last_name'  => collect([
+                'first_part' => false,
+                'last_part'  => [],
+            ]),
+            'full_name'  => [
+                'first_part' => true,
+                'last_part'  => collect([
+                    'additional_part' => '',
+                ]),
+            ],
+        ])->nullify();
+
+        $expected = Collection::make([
+            'first_name' => [
+                'first_part' => false,
+                'last_part'  => null,
+            ],
+            'last_name'  => collect([
+                'first_part' => false,
+                'last_part'  => null,
+            ]),
+            'full_name'  => [
+                'first_part' => true,
+                'last_part'  => collect([
+                    'additional_part' => null,
+                ]),
+            ],
+        ]);
+
+        $this->assertEquals($expected, $nullified);
+    }
+}

--- a/tests/Macros/NullifyTest.php
+++ b/tests/Macros/NullifyTest.php
@@ -40,7 +40,7 @@ class NullifyTest extends TestCase
             'full_name'  => collect(['first_part' => new \SplObjectStorage, 'last_part' => collect(['additional_part' => ''])]),
         ])->nullify()->toArray();
 
-        $this->assertEquals([
+        $this->assertSame([
             'test'       => null,
             'first_name' => ['first_part' => false, 'last_part' => null],
             'last_name'  => ['first_part' => true, 'last_part' => null],


### PR DESCRIPTION
### Use case
We thought about a way to standardize blank values in our API responses, so we concluded it would be nice if any value considered by Laravel as "blank" (through a `blank` helper) should be represented as `null` in the JSON response.

So, any `'', [], collect()` or objects implementing `Countable` will cast to `null`. 

I wrote a macro to perform such a transformation on an instance of collection:
```php
collect($data)->nullify();
```