### PR TITLE
Fix warnings on running the test suite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         "illuminate/support": "^8.71|^9.0"
     },
     "require-dev": {
-        "amphp/parallel": "^0.2.5",
-        "amphp/parallel-functions": "^0.1.3",
+        "amphp/parallel": "^1.4.1",
+        "amphp/parallel-functions": "^1.1.0",
         "mockery/mockery": "^1.4.2",
         "orchestra/testbench": "^6.23|^7.0",
         "phpunit/phpunit": "^9.4.4",

--- a/tests/Macros/PluckManyTest.php
+++ b/tests/Macros/PluckManyTest.php
@@ -35,9 +35,9 @@ class PluckManyTest extends TestCase
 
         $this->assertEquals(
             [
-            (object) ['name' => 'matt', 'hobby' => 'coding'],
-            ['name' => 'tomo', 'hobby' => 'cooking'],
-        ],
+                (object) ['name' => 'matt', 'hobby' => 'coding'],
+                ['name' => 'tomo', 'hobby' => 'cooking'],
+            ],
             $data->pluckMany(['name', 'hobby'])->all()
         );
     }
@@ -52,9 +52,9 @@ class PluckManyTest extends TestCase
 
         $this->assertEquals(
             [
-            ['name' => 'marco', 'hobby' => 'drinking'],
-            ['name' => 'belle', 'hobby' => 'cross-stitch'],
-        ],
+                ['name' => 'marco', 'hobby' => 'drinking'],
+                ['name' => 'belle', 'hobby' => 'cross-stitch'],
+            ],
             $data->pluckMany(['name', 'hobby'])->all()
         );
     }
@@ -69,22 +69,22 @@ class TestArrayAccessImplementation implements ArrayAccess
         $this->arr = $arr;
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->arr[$offset]);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->arr[$offset];
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->arr[$offset] = $value;
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->arr[$offset]);
     }


### PR DESCRIPTION
When running the test suite there are some warnings regarding static types. Those are for a class in the test suite and the other one is for the use of classes from `amphp` packages.

In order to fix this issue I added the missing types and updated the `amphp` packages. 

![image](https://user-images.githubusercontent.com/10696975/201123621-2b8008df-d2d1-4a9c-a26a-5bc903e4021c.png)

![image](https://user-images.githubusercontent.com/10696975/201123678-2eb710a2-1967-496c-87e1-e181b3865e8c.png)
