### PR TITLE
added pluckManyValues; extended pluckMany

### DIFF
--- a/src/Macros/PluckManyValues.php
+++ b/src/Macros/PluckManyValues.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Spatie\CollectionMacros\Macros;
+
+use ArrayAccess;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+
+/**
+ * Get a Collection with only the specified keys.
+ *
+ * @param  array  $keys
+ *
+ * @mixin \Illuminate\Support\Collection
+ *
+ * @return Collection
+ */
+class PluckManyValues
+{
+    public function __invoke()
+    {
+        return function ($keys): Collection {
+            // Allow passing multiple keys as multiple arguments
+            $keys = is_array($keys) ? $keys : func_get_args();
+            return $this->pluckMany($keys)->map(function ($item) {
+                if ($item instanceof Collection) {
+                    return $item->values();
+                }
+
+                if (is_array($item)) {
+                    return array_values($item);
+                }
+
+                // if ($item instanceof ArrayAccess) {
+                //     return collect($keys)->mapWithKeys(function ($key) use ($item) {
+                //         return [$key => $item[$key]];
+                //     })->toArray();
+                // }
+
+                return (object) array_values(get_object_vars($item));
+            });
+        };
+    }
+}


### PR DESCRIPTION
Added pluckManyValues, the PHP version of

```js
_.mixin({
    pluckMany: function (collection, keys) {
        keys = _.castArray(keys)
        return _.map(collection, (v) => _.pick(v, keys))
    },
    pluckManyValues: function (collection, keys) {
        return _.map(_.pluckMany(collection, keys), _.values)
    },
});
```

Also modified existing PluckMany.php to optionally accept keys as sequential arguments, e.g. 
```php
$collection->pluckMany('name', 'id', 'number');
```

_Note: in my humble opinion, pluckMany should only return values, however since widely used lodash extensions have been written that return key/value pairs (as does your pluckMany), this is the next best solution._