### PR TITLE
Update `recursive` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,13 +717,16 @@ $collection
 Convert an array and its children to collection using recursion.
 
 ```php
-collect([
+$collection = collect([
   'item' => [
      'children' => []
   ]   
 ])->recursive();
 
-// subsequent arrays are now collections
+$collection->first()->children;
+$collection->item->children;
+
+// subsequent arrays are now collections and allows object-like access to items
 ```
 
 In some cases you may not want to turn all the children into a collection. You can convert only to a certain depth by providing a number to the recursive method.
@@ -758,6 +761,24 @@ collect([
   }); // Collection(['item' => Collection(['children' => ['one' => Model(), 'two' => Model()]])])
 
 // If we do not pass a max depth we will get the error "Argument #1 ($attributes) must be of type array"
+```
+
+There also may be times where you need to customize the recursion exit criteria. You may do this by passing a closure which returns `true` if the recursion should cease and `false` otherwise.
+
+The closure accepts the current value, $key and depth, as well as the maximum depth for reference.
+```php
+collect([
+  'item' => [
+     'children' => [
+        'one' => now(),
+     ]
+  ]
+])
+  ->recursive(
+      shouldExit: fn ($value, $key, $depth, $maxDepth) => $value instanceof Carbon
+  );
+
+// Prevents Carbon instances from being converted to collections
 ```
 
 ### `rotate`

--- a/src/Macros/Recursive.php
+++ b/src/Macros/Recursive.php
@@ -27,16 +27,19 @@ class Recursive
         ): Collection {
             return $this->transform(function ($value, $key) use ($depth, $maxDepth, $shouldExit) {
                 if (
-                    $depth > $maxDepth
-                    || $value instanceof Closure
-                    || ! (is_array($value) || is_object($value))
-                    || ($shouldExit && $shouldExit($value, $key, $depth, $maxDepth))
+                    ! ($depth > $maxDepth)
+                    && ! ($value instanceof Closure)
+                    && (is_array($value) || is_object($value))
+                    && ! ($shouldExit && $shouldExit($value, $key, $depth, $maxDepth))
                 ) {
-                    return $this->{$key} = $value;
+                    $value = (new static($value))->recursive($maxDepth, $depth + 1, $shouldExit);
                 }
 
-                return $this->{$key} = (new static($value))
-                    ->recursive($maxDepth, $depth + 1, $shouldExit);
+                if (is_string($key)) {
+                    $this->{$key} = $value;
+                }
+
+                return $value;
             });
         };
     }

--- a/src/Macros/Recursive.php
+++ b/src/Macros/Recursive.php
@@ -6,7 +6,7 @@ use Closure;
 use Illuminate\Support\Collection;
 
 /**
- * Recursivly convert arrays and objects within a multi-dimensional array to Collections
+ * Recursively convert arrays and objects within a multi-dimensional array to Collections
  *
  * @param float $maxDepth
  * @param int $depth

--- a/tests/Macros/RecursiveTest.php
+++ b/tests/Macros/RecursiveTest.php
@@ -56,13 +56,26 @@ class RecursiveTest extends TestCase
     public function it_allows_object_like_access_to_items(): void
     {
         $collection = Collection::make([
-            'child' => [ 1, 2, 3, 'anotherchild' => (object) [1, 2, 3]],
+            'child' => ['intchild' => 1, 2, 3, 'anotherchild' => (object) [1, 2, 3]],
         ])
             ->recursive();
 
         $this->assertInstanceOf(Collection::class, $collection->child);
         $this->assertInstanceOf(Collection::class, $collection->child->anotherchild);
-        $this->assertInstanceOf(Collection::class, $collection->first()->anotherchild);
+        $this->assertIsInt($collection->child->intchild);
+    }
+
+    /** @test */
+    public function it_does_not_add_properties_for_integer_keys(): void
+    {
+        $collection = Collection::make([
+            'child' => [1 => 'notproperty', 2, 3, 'anotherchild' => (object) [1, 2, 3]],
+        ])
+            ->recursive();
+
+        $this->expectExceptionMessage('Property [1] does not exist on this collection instance.');
+
+        $collection->child->{'1'};
     }
 
     /** @test */

--- a/tests/Macros/RecursiveTest.php
+++ b/tests/Macros/RecursiveTest.php
@@ -2,13 +2,15 @@
 
 namespace Spatie\CollectionMacros\Test\Macros;
 
+use Closure;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Spatie\CollectionMacros\Test\TestCase;
 
 class RecursiveTest extends TestCase
 {
     /** @test */
-    public function it_coverts_child_arrays_to_collections()
+    public function it_coverts_child_arrays_to_collections(): void
     {
         $collection = Collection::make([
             'child' => [
@@ -22,7 +24,7 @@ class RecursiveTest extends TestCase
     }
 
     /** @test */
-    public function it_coverts_child_objects_to_collections()
+    public function it_coverts_child_objects_to_collections(): void
     {
         $collection = Collection::make([
             'child' => (object) [1, 2, 3, 'anotherchild' => (object) [1, 2, 3]],
@@ -34,7 +36,7 @@ class RecursiveTest extends TestCase
     }
 
     /** @test */
-    public function it_coverts_child_arrays_to_collections_with_a_max_depth()
+    public function it_coverts_child_arrays_to_collections_with_a_max_depth(): void
     {
         $collection = Collection::make([
             'child' => [
@@ -49,4 +51,67 @@ class RecursiveTest extends TestCase
         $this->assertInstanceOf(Collection::class, $collection['child']['anotherchild']);
         $this->assertIsArray($collection['child']['anotherchild']['lastchild']);
     }
+
+    /** @test */
+    public function it_allows_object_like_access_to_items(): void
+    {
+        $collection = Collection::make([
+            'child' => [ 1, 2, 3, 'anotherchild' => (object) [1, 2, 3]],
+        ])
+            ->recursive();
+
+        $this->assertInstanceOf(Collection::class, $collection->child);
+        $this->assertInstanceOf(Collection::class, $collection->child->anotherchild);
+        $this->assertInstanceOf(Collection::class, $collection->first()->anotherchild);
+    }
+
+    /** @test */
+    public function it_respects_inheritance(): void
+    {
+        $collection = ChildCollection::make([
+            'child' => [1, 2, 3, 'anotherchild' => (object) [1, 2, 3]],
+        ])
+            ->recursive();
+
+        $this->assertInstanceOf(ChildCollection::class, $collection->child);
+        $this->assertInstanceOf(ChildCollection::class, $collection->child->anotherchild);
+    }
+
+    /** @test */
+    public function it_ignores_closures(): void
+    {
+        $collection = Collection::make([
+            'child' => [
+                1, 2, 3, 'anotherchild' => fn () => 1 + 2,
+            ],
+        ])
+            ->recursive();
+
+        $this->assertInstanceOf(Collection::class, $collection->child);
+        $this->assertInstanceOf(Closure::class, $collection->child->anotherchild);
+    }
+
+    /** @test */
+    public function it_accepts_callback_to_extend_exit_conditions(): void
+    {
+        $collection = Collection::make([
+            'child' => [1, 2, 3, 'anotherchild' => now()],
+        ])
+            ->recursive();
+
+        $this->assertInstanceOf(Collection::class, $collection->child->anotherchild);
+
+        $collection = Collection::make([
+            'child' => [1, 2, 3, 'anotherchild' => now()],
+        ])
+            ->recursive(
+                shouldExit: fn ($value, $key, $depth, $maxDepth) => $value instanceof Carbon,
+            );
+
+        $this->assertInstanceOf(Carbon::class, $collection->child->anotherchild);
+    }
+}
+
+class ChildCollection extends Collection
+{
 }


### PR DESCRIPTION
Hello!

This PR updates the `recursive` macro to:

1. Ignore Closures (prevents segmentation faults, taken from #225)
1. Respect inheritance
1. Set properties on collection for object-like item access (`$collection->item` vs. `$collection['item']`)
1. Accept closure to extend recursion exit conditions

Most of this was inspired from @joserick's macros:
- [Combination of the 1) the original macro @brunogaspar, 2) @lorisleiva 's tweak and 3) the modification by @jonaslm.](https://gist.github.com/brunogaspar/154fb2f99a7f83003ef35fd4b5655935?permalink_comment_id=3749071#gistcomment-3749071)
- [Combination of ["Collect Recursive with depth"] and ["Access collect items as properties"] (improved*)](https://gist.github.com/brunogaspar/154fb2f99a7f83003ef35fd4b5655935?permalink_comment_id=4410835#gistcomment-4410835)

The latter macro was interesting as it returned an anonymous Collection instance which overrode the `__get` and `__set` magic methods (allowing access to collection items as properties without having to define properties). However, I could not get the anonymous class to properly inherit the child collection instance (which was important to an individual on the above Gist thread) so fell back to creating the properties on the collections.


Thanks!