### PR TITLE
Create `keysToProperties` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The package will automatically register itself.
 - [`insertAt`](#insertat)
 - [`insertBefore`](#insertbefore)
 - [`insertBeforeKey`](#insertbeforekey)
+- [`keysToProperties`](#keysToProperties)
 - [`none`](#none)
 - [`paginate`](#paginate)
 - [`parallelMap`](#parallelmap)
@@ -552,6 +553,16 @@ collect(['zero', 'two', 'three'])->insertBeforeKey(1, 'one');
 
 collect(['zero' => 0, 'two' => 2, 'three' => 3]->insertBeforeKey('two', 5, 'five');
 // Collection contains ['zero' => 0, 'five' => 5, 'two' => 2, 'three' => 3]
+```
+
+### `keysToProperties`
+
+Creates properties from the collection keys (only string keys);
+
+```php
+$collection = collect(['zero' => 0, 'two' => 2, 'three' => 3])
+    ->keysToProperties();
+// Collection items can now be accessed as properties: `$collection->zero` vs `$collection['zero']`
 ```
 
 ### `none`

--- a/src/CollectionMacroServiceProvider.php
+++ b/src/CollectionMacroServiceProvider.php
@@ -45,6 +45,7 @@ class CollectionMacroServiceProvider extends ServiceProvider
             'insertAt' => \Spatie\CollectionMacros\Macros\InsertAt::class,
             'insertBefore' => \Spatie\CollectionMacros\Macros\InsertBefore::class,
             'insertBeforeKey' => \Spatie\CollectionMacros\Macros\InsertBeforeKey::class,
+            'keysToProperties' => \Spatie\CollectionMacros\Macros\KeysToProperties::class,
             'ninth' => \Spatie\CollectionMacros\Macros\Ninth::class,
             'none' => \Spatie\CollectionMacros\Macros\None::class,
             'paginate' => \Spatie\CollectionMacros\Macros\Paginate::class,

--- a/src/Macros/KeysToProperties.php
+++ b/src/Macros/KeysToProperties.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Spatie\CollectionMacros\Macros;
+
+use Illuminate\Support\Collection;
+
+/**
+ * Creates properties from the (string) keys of the collection
+ *
+ * @mixin \Illuminate\Support\Collection
+ *
+ * @return \Illuminate\Support\Collection
+ */
+class KeysToProperties
+{
+    public function __invoke()
+    {
+        return function (): Collection {
+            return $this->transform(function ($value, $key) {
+                if (is_string($key)) {
+                    $this->{$key} = $value;
+                }
+
+                return $value;
+            });
+        };
+    }
+}

--- a/tests/Macros/KeysToPropertiesTest.php
+++ b/tests/Macros/KeysToPropertiesTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\CollectionMacros\Test\Macros;
+
+use Illuminate\Support\Collection;
+use Spatie\CollectionMacros\Test\TestCase;
+
+class KeysToPropertiesTest extends TestCase
+{
+    /** @test */
+    public function it_creates_properties_from_string_keys()
+    {
+        $collection = Collection::make([
+            'child' => [1, 2, 3],
+            'anotherchild' => [1, 2, 3],
+        ])->keysToProperties();
+
+        $this->assertTrue(property_exists($collection, 'child'));
+        $this->assertTrue(property_exists($collection, 'anotherchild'));
+    }
+
+    /** @test */
+    public function it_does_not_create_properties_for_integer_keys()
+    {
+        $collection = Collection::make([1, 2, 3])
+            ->keysToProperties();
+
+        $this->assertFalse(property_exists($collection, 0));
+    }
+}


### PR DESCRIPTION
Hello!

This PR creates the `keysToProperties` macro which converts all string keys to properties---I often want to be able to access the items in a collection like an object: e.g., `$collection->foo` instead of `$collection['foo']`


Thanks!
