### PR TITLE
feat(collectBy): support dot-notation

### DIFF
--- a/src/Macros/CollectBy.php
+++ b/src/Macros/CollectBy.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\CollectionMacros\Macros;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 /**
@@ -19,7 +20,7 @@ class CollectBy
     public function __invoke()
     {
         return function ($key, $default = null): Collection {
-            return new static($this->get($key, $default));
+            return new static(Arr::get($this->items, $key, $default));
         };
     }
 }

--- a/tests/Macros/CollectByTest.php
+++ b/tests/Macros/CollectByTest.php
@@ -60,3 +60,22 @@ it('returns empty collection when missing key without default', function () {
 
     expect($ingredients)->toEqual(new Collection());
 });
+
+it('collects path from collection using dot notation', function () {
+    $collection = new Collection([
+        'baz.qux' => 'quux',
+        'foo' => [
+            'bar' => [
+                'baz' => 100,
+            ],
+        ],
+    ]);
+
+    expect($collection->collectBy('foo.bar'))->toBeInstanceOf(Collection::class);
+    expect($collection->collectBy('foo.bar')->toArray())->toEqual([
+        'baz' => 100,
+    ]);
+
+    expect($collection->collectBy('baz.qux'))->toBeInstanceOf(Collection::class);
+    expect($collection->collectBy('baz.qux')->toArray())->toEqual(['quux']);
+});


### PR DESCRIPTION
This pull request adds dot-notation support to `collectBy`. This is a pattern I use almost every day when working with data and third-party services.

```php
$collection->collectBy('aircraft.aoc') // Collection
```

This is not a breaking change, as paths containing a dot will behave as before.