### PR TITLE
pluckMany dotted key support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 All notable changes to `laravel-collection-macros` will be documented in this file
 
-## 7.xx.x - 2023-1x-xx
-
-### What's Changed
-
-- feat(pluckMany): support dot-notation by @sfinktah in https://github.com/spatie/laravel-collection-macros/pull/xxx
-
 ## 7.13.1 - 2023-10-17
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-collection-macros` will be documented in this file
 
+## 7.xx.x - 2023-1x-xx
+
+### What's Changed
+
+- feat(pluckMany): support dot-notation by @sfinktah in https://github.com/spatie/laravel-collection-macros/pull/xxx
+
 ## 7.13.1 - 2023-10-17
 
 ### What's Changed

--- a/tests/Macros/PluckManyTest.php
+++ b/tests/Macros/PluckManyTest.php
@@ -40,3 +40,39 @@ it('can pluck from objects that implement array access interface', function () {
         ['name' => 'belle', 'hobby' => 'cross-stitch'],
     ]);
 });
+
+it('can pluck dot-notated keys from a collection of collections', function () {
+    $data = Collection::make([
+        collect(['id' => 1, 'name' => 'matt', 'info' => ['hobby' => 'coding']]),
+        collect(['id' => 2, 'name' => 'tomo', 'info' => ['hobby' => 'cooking']]),
+    ]);
+
+    expect($data->pluckMany(['name', 'info.hobby']))->toEqual(collect([
+        collect(['name' => 'matt', 'info.hobby' => 'coding']),
+        collect(['name' => 'tomo', 'info.hobby' => 'cooking'])
+    ]));
+});
+
+it('can pluck dot-notated keys from array and object items', function () {
+    $data = Collection::make([
+        (object) ['id' => 1, 'name' => 'matt', 'info' => ['hobby' => 'coding']],
+        ['id' => 2, 'name' => 'tomo', 'info' => ['hobby' => 'cooking']],
+    ]);
+
+    expect($data->pluckMany(['name', 'info.hobby'])->all())->toEqual([
+        (object) ['name' => 'matt', 'info.hobby' => 'coding'],
+        ['name' => 'tomo', 'info.hobby' => 'cooking'],
+    ]);
+});
+
+it('can pluck dot-notated keys from objects that implement array access interface', function () {
+    $data = Collection::make([
+        new TestArrayAccessImplementation(['id' => 1, 'name' => 'marco', 'info' => ['hobby' => 'drinking']]),
+        new TestArrayAccessImplementation(['id' => 2, 'name' => 'belle', 'info' => ['hobby' => 'cross-stitch']]),
+    ]);
+
+    expect($data->pluckMany(['name', 'info.hobby'])->all())->toEqual([
+        ['name' => 'marco', 'info.hobby' => 'drinking'],
+        ['name' => 'belle', 'info.hobby' => 'cross-stitch'],
+    ]);
+});


### PR DESCRIPTION
To bring `pluckMany` inline with various other `pluck` implementations, including `Collections::pluck` (`Arr::pluck`), this allows the specification of dotted keys.

e.g.,

```php
$ar = collect($chunk)
    ->pluckMany(['id', 'handle', 'variants.edges.0.node.sku', 'spaghetti']);
```
