### PR TITLE
fix: php 8.4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,7 +610,7 @@ collect($posts)->paginate(5);
 This paginates the contents of `$posts` with 5 items per page. `paginate` accepts quite some options, head over to [the Laravel docs](https://laravel.com/docs/5.4/pagination) for an in-depth guide.
 
 ```
-paginate(int $perPage = 15, string $pageName = 'page', int $page = null, int $total = null, array $options = [])
+paginate(int $perPage = 15, string $pageName = 'page', ?int $page = null, ?int $total = null, array $options = [])
 ```
 
 ### `path`
@@ -806,7 +806,7 @@ collect($posts)->simplePaginate(5);
 This paginates the contents of `$posts` with 5 items per page. `simplePaginate` accepts quite some options, head over to [the Laravel docs](https://laravel.com/docs/5.4/pagination) for an in-depth guide.
 
 ```
-simplePaginate(int $perPage = 15, string $pageName = 'page', int $page = null, int $total = null, array $options = [])
+simplePaginate(int $perPage = 15, string $pageName = 'page', ?int $page = null, ?int $total = null, array $options = [])
 ```
 
 For a in-depth guide on pagination, check out [the Laravel docs](https://laravel.com/docs/5.4/pagination).

--- a/src/Macros/Paginate.php
+++ b/src/Macros/Paginate.php
@@ -20,7 +20,7 @@ class Paginate
 {
     public function __invoke()
     {
-        return function (int $perPage = 15, string $pageName = 'page', int $page = null, int $total = null, array $options = []): LengthAwarePaginator {
+        return function (int $perPage = 15, string $pageName = 'page', ?int $page = null, ?int $total = null, array $options = []): LengthAwarePaginator {
             $page = $page ?: LengthAwarePaginator::resolveCurrentPage($pageName);
 
             $results = $this->forPage($page, $perPage)->values();

--- a/src/Macros/SimplePaginate.php
+++ b/src/Macros/SimplePaginate.php
@@ -19,7 +19,7 @@ class SimplePaginate
 {
     public function __invoke()
     {
-        return function (int $perPage = 15, string $pageName = 'page', int $page = null, array $options = []): Paginator {
+        return function (int $perPage = 15, string $pageName = 'page', ?int $page = null, array $options = []): Paginator {
             $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
             $results = $this->slice(($page - 1) * $perPage)->take($perPage + 1);


### PR DESCRIPTION
Hello!

This removes the deprecation warnings on PHP 8.4 by using explicit nullable types.

Thanks!